### PR TITLE
Add Actions resolver support

### DIFF
--- a/src/db/archive-node-adapter/queries.ts
+++ b/src/db/archive-node-adapter/queries.ts
@@ -1,0 +1,88 @@
+import type postgres from 'postgres';
+import { BlockStatusFilter } from '../../resolvers-types';
+
+function accountIdentifierCTE(
+  db_client: postgres.Sql,
+  address: string,
+  tokenId: string
+) {
+  return db_client`
+    account_identifier AS (
+      SELECT id 
+      FROM account_identifiers ai
+      WHERE ai.public_key_id = (SELECT id FROM public_keys WHERE value = ${address})
+      AND ai.token_id = (SELECT id FROM tokens WHERE value = ${tokenId})
+    )`;
+}
+
+function blocksAccessedCTE(
+  db_client: postgres.Sql,
+  status: BlockStatusFilter,
+  to?: string,
+  from?: string
+) {
+  return db_client`
+    blocks_accessed AS (
+      SELECT *
+      FROM account_identifier ai
+      INNER JOIN accounts_accessed aa
+      ON ai.id = aa.account_identifier_id
+      INNER JOIN blocks b
+      ON aa.block_id = b.id
+      WHERE chain_status <> 'orphaned'
+      ${
+        status === BlockStatusFilter.all
+          ? db_client``
+          : db_client`AND chain_status = ${status.toLowerCase()}`
+      }
+      ${to ? db_client`AND b.height <= ${to}` : db_client``}
+      ${from ? db_client`AND b.height >= ${from}` : db_client``}
+    )`;
+}
+
+function emittedZkAppCommandsCTE(db_client: postgres.Sql) {
+  return db_client`
+    emitted_zkapp_commands AS (
+      SELECT *
+      FROM blocks_accessed
+      INNER JOIN blocks_zkapp_commands bzkc
+      ON blocks_accessed.block_id = bzkc.block_id
+      INNER JOIN zkapp_commands zkc
+      ON bzkc.zkapp_command_id = zkc.id
+      INNER JOIN zkapp_account_update zkcu
+      ON zkcu.id = ANY(zkc.zkapp_account_updates_ids)
+      INNER JOIN zkapp_account_update_body zkcu_body
+      ON zkcu_body.id = zkcu.body_id
+    )`;
+}
+
+function emittedEventsCTE(db_client: postgres.Sql) {
+  return db_client`
+  emitted_events AS (
+    SELECT *
+    FROM emitted_zkapp_commands
+    INNER JOIN zkapp_events zke
+    ON zke.id = events_id
+    INNER JOIN zkapp_state_data_array zksda
+    ON zksda.id = ANY(zke.element_ids)
+    INNER JOIN zkapp_state_data zksd
+    ON zksd.id = ANY(zksda.element_ids)
+  )`;
+}
+
+export function getEventsQuery(
+  db_client: postgres.Sql,
+  address: string,
+  tokenId: string,
+  status: BlockStatusFilter,
+  to?: string,
+  from?: string
+) {
+  return db_client`
+    WITH ${accountIdentifierCTE(db_client, address, tokenId)},
+    ${blocksAccessedCTE(db_client, status, to, from)},
+    ${emittedZkAppCommandsCTE(db_client)},
+    ${emittedEventsCTE(db_client)}
+    SELECT *
+    FROM emitted_events`;
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,9 +1,10 @@
 import type { EventFilterOptionsInput } from '../resolvers-types';
-import type { Events } from '../models/types';
+import type { Actions, Events } from '../models/types';
 import { ArchiveNodeAdapter } from './archive-node-adapter';
 
 export interface DatabaseAdapter {
   getEvents(input: EventFilterOptionsInput): Promise<Events>;
+  getActions(input: EventFilterOptionsInput): Promise<Actions>;
 }
 
 export { ArchiveNodeAdapter };

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -12,6 +12,10 @@ export type Event = {
   fields: string[];
 };
 
+export type Action = {
+  data: string[];
+};
+
 export type BlockInfo = {
   height: string;
   stateHash: string;
@@ -32,6 +36,12 @@ export type TransactionInfo = {
 
 export type Events = {
   eventData: Event[];
+  blockInfo: BlockInfo;
+  transactionInfo: TransactionInfo;
+}[];
+
+export type Actions = {
+  actionData: Action[];
   blockInfo: BlockInfo;
   transactionInfo: TransactionInfo;
 }[];

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -1,4 +1,4 @@
-import type { BlockInfo, TransactionInfo, Event } from './types';
+import type { BlockInfo, TransactionInfo, Event, Action } from './types';
 
 export function createBlockInfo(row: any) {
   return {
@@ -27,4 +27,10 @@ export function createEvent(index: string, fields: string[]) {
     index,
     fields,
   } as Event;
+}
+
+export function createAction(data: string[]) {
+  return {
+    data,
+  } as Action;
 }

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -50,9 +50,9 @@ export type EventData = {
 
 export type EventFilterOptionsInput = {
   address: Scalars['String'];
-  from?: InputMaybe<Scalars['String']>;
+  from?: InputMaybe<Scalars['Int']>;
   status?: InputMaybe<BlockStatusFilter>;
-  to?: InputMaybe<Scalars['String']>;
+  to?: InputMaybe<Scalars['Int']>;
   tokenId?: InputMaybe<Scalars['String']>;
 };
 
@@ -164,6 +164,7 @@ export type ResolversTypes = {
   EventData: ResolverTypeWrapper<EventData>;
   EventFilterOptionsInput: EventFilterOptionsInput;
   EventOutput: ResolverTypeWrapper<EventOutput>;
+  Int: ResolverTypeWrapper<Scalars['Int']>;
   Query: ResolverTypeWrapper<{}>;
   String: ResolverTypeWrapper<Scalars['String']>;
   TransactionInfo: ResolverTypeWrapper<TransactionInfo>;
@@ -178,6 +179,7 @@ export type ResolversParentTypes = {
   EventData: EventData;
   EventFilterOptionsInput: EventFilterOptionsInput;
   EventOutput: EventOutput;
+  Int: Scalars['Int'];
   Query: {};
   String: Scalars['String'];
   TransactionInfo: TransactionInfo;

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -18,13 +18,13 @@ export type Scalars = {
 
 export type ActionData = {
   __typename?: 'ActionData';
-  data: Scalars['String'];
+  data: Array<Maybe<Scalars['String']>>;
 };
 
 export type ActionOutput = {
   __typename?: 'ActionOutput';
+  actionData?: Maybe<Array<Maybe<ActionData>>>;
   blockInfo?: Maybe<BlockInfo>;
-  eventData?: Maybe<Array<Maybe<ActionData>>>;
   transactionInfo?: Maybe<TransactionInfo>;
 };
 
@@ -65,7 +65,7 @@ export type EventOutput = {
 
 export type Query = {
   __typename?: 'Query';
-  actions: Array<Maybe<ActionData>>;
+  actions: Array<Maybe<ActionOutput>>;
   events: Array<Maybe<EventOutput>>;
 };
 
@@ -186,13 +186,13 @@ export type ResolversParentTypes = {
 };
 
 export type ActionDataResolvers<ContextType = any, ParentType extends ResolversParentTypes['ActionData'] = ResolversParentTypes['ActionData']> = {
-  data?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  data?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type ActionOutputResolvers<ContextType = any, ParentType extends ResolversParentTypes['ActionOutput'] = ResolversParentTypes['ActionOutput']> = {
+  actionData?: Resolver<Maybe<Array<Maybe<ResolversTypes['ActionData']>>>, ParentType, ContextType>;
   blockInfo?: Resolver<Maybe<ResolversTypes['BlockInfo']>, ParentType, ContextType>;
-  eventData?: Resolver<Maybe<Array<Maybe<ResolversTypes['ActionData']>>>, ParentType, ContextType>;
   transactionInfo?: Resolver<Maybe<ResolversTypes['TransactionInfo']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -225,7 +225,7 @@ export type EventOutputResolvers<ContextType = any, ParentType extends Resolvers
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
-  actions?: Resolver<Array<Maybe<ResolversTypes['ActionData']>>, ParentType, ContextType, RequireFields<QueryActionsArgs, 'input'>>;
+  actions?: Resolver<Array<Maybe<ResolversTypes['ActionOutput']>>, ParentType, ContextType, RequireFields<QueryActionsArgs, 'input'>>;
   events?: Resolver<Array<Maybe<ResolversTypes['EventOutput']>>, ParentType, ContextType, RequireFields<QueryEventsArgs, 'input'>>;
 };
 

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -16,8 +16,17 @@ const resolvers: Resolvers = {
       );
       return fetchedEvents;
     },
-    actions: (_, { input }, { db_client }) => {
-      return [];
+    actions: async (_, { input }, { db_client }) => {
+      const start = process.hrtime();
+      let fetchedActions = await db_client.getActions(input);
+      const end = process.hrtime(start);
+
+      console.info(
+        'Actions Resolver Execution Time: %ds %dms',
+        end[0],
+        end[1] / 1000000
+      );
+      return fetchedActions;
     },
   },
 };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -9,8 +9,8 @@ export const typeDefinitions = /* GraphQL */ `
     address: String!
     tokenId: String
     status: BlockStatusFilter
-    to: String
-    from: String
+    to: Int
+    from: Int
   }
 
   type EventData {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -19,7 +19,7 @@ export const typeDefinitions = /* GraphQL */ `
   }
 
   type ActionData {
-    data: String!
+    data: [String]!
   }
 
   type BlockInfo {
@@ -49,11 +49,11 @@ export const typeDefinitions = /* GraphQL */ `
   type ActionOutput {
     blockInfo: BlockInfo
     transactionInfo: TransactionInfo
-    eventData: [ActionData]
+    actionData: [ActionData]
   }
 
   type Query {
     events(input: EventFilterOptionsInput!): [EventOutput]!
-    actions(input: EventFilterOptionsInput!): [ActionData]!
+    actions(input: EventFilterOptionsInput!): [ActionOutput]!
   }
 `;


### PR DESCRIPTION
## Description
Adds support for the actions resolver in the GraphQL server. This PR has the following changes:
1. Some refactoring to move the used SQL into its module and then defines a separate CTE for fetching actions. 
2. Adds additional code to the `ArchiveNodeAdapter` class to use the newly defined SQL
3. Fixes some issues with the schema when actions still needed to be implemented. The schema was just defined incorrectly for actions previously.

## Screenshots
The screenshot below shows a GraphiQL environment that issues a `actions` query, and it's output.
![image](https://user-images.githubusercontent.com/9512405/218589442-e47d936e-c09a-485c-a656-78aef8ea6611.png)

## Impact
This allows querying for actions on the current running Berkeley network. One important note is that the current Berkeley archive node uses an older schema that references actions as `sequence_events`, so the SQL must be updated in a follow-up PR when Berkeley is redeployed.

## Testing
Manually tested using a [Berkely Archive Node dump as of February 13th](https://storage.googleapis.com/mina-archive-dumps/berkeley-archive-dump-2023-02-13_0000.sql.tar.gz.