### PR TITLE
feat: Add Dockerfile to build and run server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ node_modules
 .DS_Store
 
 # Ignore built ts files
-dist/**/*
+build/**/*
 
+# Ignore development SQL dump
 scripts/data/**/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Stage 1: Build the TypeScript code
+FROM node:14 as build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: Copy the built code and install the production dependencies
+FROM node:14
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+COPY --from=build /app/build /app/build
+EXPOSE 8080
+CMD [ "npm", "start" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "@types/node": "^18.11.18",
         "cross-env": "^7.0.3",
         "prettier": "2.8.3",
-        "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
   "name": "archive-node-graphql",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "description": "A NodeJS GraphQL server for exposing data for SnarkyJS/zkApps",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/o1-labs/Archive-Node-API"
+  },
+  "main": "build/src/index.js",
   "scripts": {
+    "build": "tsc",
+    "start": "node build/src/index.js",
     "dev": "cross-env NODE_ENV=development ts-node-dev --exit-child --respawn src/index.ts",
-    "start": "ts-node src/index.ts",
     "generate": "graphql-codegen"
   },
   "keywords": [],
@@ -18,7 +23,6 @@
     "@types/node": "^18.11.18",
     "cross-env": "^7.0.3",
     "prettier": "2.8.3",
-    "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 import { buildServer } from './build';
-let PORT = process.env.PORT || 4000;
+let PORT = process.env.PORT || 8080;
 
 let server = buildServer();
 server.listen(PORT, () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,9 +26,9 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    "rootDir": "./",                                     /* Specify the root folder within your source files. */
+    "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
+    "baseUrl": "./",                                     /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
@@ -47,10 +47,10 @@
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true,                                   /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
+    "outDir": "./build",                                   /* Specify an output folder for all emitted files. */
+    "removeComments": true,                              /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
@@ -99,5 +99,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src/**/*", "package.json"]
 }


### PR DESCRIPTION
## Description
Adds a Dockerfile to build and run the server. The Dockerfile has two stages, one for building the code and another for installing production dependencies. 

## Impact
This Dockerfile gives an easy way to deploy the application in a container. This allows for running the application in many different environments.

## Testing
Built the docker image and ran it locally.
**Build**: 
`docker build . --tag archive-node-api`

**Run**: 
`docker run --network="host" --env PG_CONN="postgres://postgres:password@localhost:5432/archive" --env ENABLE_GRAPHIQL="true" --env ENABLE_INTROSPECTION="true" archive-node-api`

Addressed #2 
