### PR TITLE
Add distance from max block height 

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -5,6 +5,7 @@ const config: CodegenConfig = {
   generates: {
     './src/resolvers-types.ts': {
       config: {
+        contextType: './context#GraphQLContext',
         enumValues: {
           BlockStatusFilter: './models/types#BlockStatusFilter',
         },

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,12 @@
+import type { YogaInitialContext } from 'graphql-yoga';
+import { ArchiveNodeAdapter } from './db';
+
+export interface GraphQLContext extends YogaInitialContext {
+  db_client: ArchiveNodeAdapter;
+}
+
+export function buildContext() {
+  return {
+    db_client: new ArchiveNodeAdapter(process.env.PG_CONN),
+  };
+}

--- a/src/db/archive-node-adapter/queries.ts
+++ b/src/db/archive-node-adapter/queries.ts
@@ -9,7 +9,7 @@ function fullChainCTE(db_client: postgres.Sql) {
       FROM blocks b 
       WHERE height = (SELECT max(height) FROM blocks) 
     ) 
-    UNION ALL 
+    UNION ALL
     SELECT b.id, b.state_hash, b.parent_hash, b.parent_id, b.height, b.global_slot_since_genesis, b.global_slot_since_hard_fork, b.timestamp, b.chain_status 
     FROM blocks b 
     INNER JOIN pending_chain ON b.id = pending_chain.parent_id 
@@ -17,7 +17,7 @@ function fullChainCTE(db_client: postgres.Sql) {
     AND pending_chain.chain_status <> 'canonical'
   ), 
   full_chain AS (
-    SELECT * 
+    SELECT id, state_hash, parent_id, parent_hash, height, global_slot_since_genesis, global_slot_since_hard_fork, timestamp, chain_status, (SELECT max(height) FROM blocks) - height AS distance_from_max_block_height
     FROM 
       (
         SELECT id, state_hash, parent_id, parent_hash, height, global_slot_since_genesis, global_slot_since_hard_fork, timestamp, chain_status 
@@ -106,7 +106,8 @@ function emittedEventsCTE(db_client: postgres.Sql) {
 
 function emittedActionsCTE(db_client: postgres.Sql) {
   return db_client`
-  emitted_actions AS (
+  emitted_actions AS
+  (
     SELECT *
     FROM emitted_zkapp_commands
     INNER JOIN zkapp_events zke

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as dotenv from 'dotenv';
 dotenv.config();
 
-import { buildServer } from './build';
+import { buildServer } from './server';
 let PORT = process.env.PORT || 8080;
 
 let server = buildServer();

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -9,7 +9,7 @@ export enum BlockStatusFilter {
 
 export type Event = {
   index: string;
-  fields: string[];
+  data: string[];
 };
 
 export type Action = {
@@ -17,14 +17,15 @@ export type Action = {
 };
 
 export type BlockInfo = {
-  height: string;
+  height: number;
   stateHash: string;
   parentHash: string;
   ledgerHash: string;
   chainStatus: string;
   timestamp: string;
-  globalSlotSinceHardfork: string;
-  globalSlotSinceGenesis: string;
+  globalSlotSinceHardfork: number;
+  globalSlotSinceGenesis: number;
+  distanceFromMaxBlockHeight: number;
 };
 
 export type TransactionInfo = {

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -1,6 +1,7 @@
 import type { BlockInfo, TransactionInfo, Event, Action } from './types';
+import type postgres from 'postgres';
 
-export function createBlockInfo(row: any) {
+export function createBlockInfo(row: postgres.Row) {
   return {
     height: row.height,
     stateHash: row.state_hash,
@@ -10,10 +11,11 @@ export function createBlockInfo(row: any) {
     timestamp: row.timestamp,
     globalSlotSinceHardfork: row.global_slot_since_hard_fork,
     globalSlotSinceGenesis: row.global_slot_since_genesis,
+    distanceFromMaxBlockHeight: row.distance_from_max_block_height,
   } as BlockInfo;
 }
 
-export function createTransactionInfo(row: any) {
+export function createTransactionInfo(row: postgres.Row) {
   return {
     status: row.status,
     hash: row.hash,
@@ -22,10 +24,10 @@ export function createTransactionInfo(row: any) {
   } as TransactionInfo;
 }
 
-export function createEvent(index: string, fields: string[]) {
+export function createEvent(index: string, data: string[]) {
   return {
     index,
-    fields,
+    data,
   } as Event;
 }
 

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -33,9 +33,9 @@ export type BlockInfo = {
   __typename?: 'BlockInfo';
   chainStatus: Scalars['String'];
   distanceFromMaxBlockHeight: Scalars['Int'];
-  globalSlotSinceGenesis?: Maybe<Scalars['String']>;
-  globalSlotSinceHardfork?: Maybe<Scalars['String']>;
-  height: Scalars['String'];
+  globalSlotSinceGenesis: Scalars['Int'];
+  globalSlotSinceHardfork: Scalars['Int'];
+  height: Scalars['Int'];
   ledgerHash: Scalars['String'];
   parentHash: Scalars['String'];
   stateHash: Scalars['String'];
@@ -46,7 +46,7 @@ export { BlockStatusFilter };
 
 export type EventData = {
   __typename?: 'EventData';
-  fields: Array<Maybe<Scalars['String']>>;
+  data: Array<Maybe<Scalars['String']>>;
   index: Scalars['String'];
 };
 
@@ -202,9 +202,9 @@ export type ActionOutputResolvers<ContextType = GraphQLContext, ParentType exten
 export type BlockInfoResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['BlockInfo'] = ResolversParentTypes['BlockInfo']> = {
   chainStatus?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   distanceFromMaxBlockHeight?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  globalSlotSinceGenesis?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  globalSlotSinceHardfork?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  height?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  globalSlotSinceGenesis?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  globalSlotSinceHardfork?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  height?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   ledgerHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   parentHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -215,7 +215,7 @@ export type BlockInfoResolvers<ContextType = GraphQLContext, ParentType extends 
 export type BlockStatusFilterResolvers = EnumResolverSignature<{ ALL?: any, CANONICAL?: any, PENDING?: any }, ResolversTypes['BlockStatusFilter']>;
 
 export type EventDataResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['EventData'] = ResolversParentTypes['EventData']> = {
-  fields?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
+  data?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
   index?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -1,5 +1,6 @@
 import { BlockStatusFilter } from './models/types';
 import { GraphQLResolveInfo } from 'graphql';
+import { GraphQLContext } from './context';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -32,6 +32,7 @@ export type ActionOutput = {
 export type BlockInfo = {
   __typename?: 'BlockInfo';
   chainStatus: Scalars['String'];
+  distanceFromMaxBlockHeight: Scalars['Int'];
   globalSlotSinceGenesis?: Maybe<Scalars['String']>;
   globalSlotSinceHardfork?: Maybe<Scalars['String']>;
   height: Scalars['String'];
@@ -186,20 +187,21 @@ export type ResolversParentTypes = {
   TransactionInfo: TransactionInfo;
 };
 
-export type ActionDataResolvers<ContextType = any, ParentType extends ResolversParentTypes['ActionData'] = ResolversParentTypes['ActionData']> = {
+export type ActionDataResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['ActionData'] = ResolversParentTypes['ActionData']> = {
   data?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type ActionOutputResolvers<ContextType = any, ParentType extends ResolversParentTypes['ActionOutput'] = ResolversParentTypes['ActionOutput']> = {
+export type ActionOutputResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['ActionOutput'] = ResolversParentTypes['ActionOutput']> = {
   actionData?: Resolver<Maybe<Array<Maybe<ResolversTypes['ActionData']>>>, ParentType, ContextType>;
   blockInfo?: Resolver<Maybe<ResolversTypes['BlockInfo']>, ParentType, ContextType>;
   transactionInfo?: Resolver<Maybe<ResolversTypes['TransactionInfo']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type BlockInfoResolvers<ContextType = any, ParentType extends ResolversParentTypes['BlockInfo'] = ResolversParentTypes['BlockInfo']> = {
+export type BlockInfoResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['BlockInfo'] = ResolversParentTypes['BlockInfo']> = {
   chainStatus?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  distanceFromMaxBlockHeight?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   globalSlotSinceGenesis?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   globalSlotSinceHardfork?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   height?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -212,25 +214,25 @@ export type BlockInfoResolvers<ContextType = any, ParentType extends ResolversPa
 
 export type BlockStatusFilterResolvers = EnumResolverSignature<{ ALL?: any, CANONICAL?: any, PENDING?: any }, ResolversTypes['BlockStatusFilter']>;
 
-export type EventDataResolvers<ContextType = any, ParentType extends ResolversParentTypes['EventData'] = ResolversParentTypes['EventData']> = {
+export type EventDataResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['EventData'] = ResolversParentTypes['EventData']> = {
   fields?: Resolver<Array<Maybe<ResolversTypes['String']>>, ParentType, ContextType>;
   index?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type EventOutputResolvers<ContextType = any, ParentType extends ResolversParentTypes['EventOutput'] = ResolversParentTypes['EventOutput']> = {
+export type EventOutputResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['EventOutput'] = ResolversParentTypes['EventOutput']> = {
   blockInfo?: Resolver<Maybe<ResolversTypes['BlockInfo']>, ParentType, ContextType>;
   eventData?: Resolver<Maybe<Array<Maybe<ResolversTypes['EventData']>>>, ParentType, ContextType>;
   transactionInfo?: Resolver<Maybe<ResolversTypes['TransactionInfo']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
+export type QueryResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   actions?: Resolver<Array<Maybe<ResolversTypes['ActionOutput']>>, ParentType, ContextType, RequireFields<QueryActionsArgs, 'input'>>;
   events?: Resolver<Array<Maybe<ResolversTypes['EventOutput']>>, ParentType, ContextType, RequireFields<QueryEventsArgs, 'input'>>;
 };
 
-export type TransactionInfoResolvers<ContextType = any, ParentType extends ResolversParentTypes['TransactionInfo'] = ResolversParentTypes['TransactionInfo']> = {
+export type TransactionInfoResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TransactionInfo'] = ResolversParentTypes['TransactionInfo']> = {
   authorizationKind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   hash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   memo?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -238,7 +240,7 @@ export type TransactionInfoResolvers<ContextType = any, ParentType extends Resol
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type Resolvers<ContextType = any> = {
+export type Resolvers<ContextType = GraphQLContext> = {
   ActionData?: ActionDataResolvers<ContextType>;
   ActionOutput?: ActionOutputResolvers<ContextType>;
   BlockInfo?: BlockInfoResolvers<ContextType>;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -31,6 +31,7 @@ export const typeDefinitions = /* GraphQL */ `
     timestamp: String!
     globalSlotSinceHardfork: String
     globalSlotSinceGenesis: String
+    distanceFromMaxBlockHeight: Int!
   }
 
   type TransactionInfo {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -15,7 +15,7 @@ export const typeDefinitions = /* GraphQL */ `
 
   type EventData {
     index: String!
-    fields: [String]!
+    data: [String]!
   }
 
   type ActionData {
@@ -23,14 +23,14 @@ export const typeDefinitions = /* GraphQL */ `
   }
 
   type BlockInfo {
-    height: String!
+    height: Int!
     stateHash: String!
     parentHash: String!
     ledgerHash: String!
     chainStatus: String!
     timestamp: String!
-    globalSlotSinceHardfork: String
-    globalSlotSinceGenesis: String
+    globalSlotSinceHardfork: Int!
+    globalSlotSinceGenesis: Int!
     distanceFromMaxBlockHeight: Int!
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import { useOpenTelemetry } from '@envelop/opentelemetry';
 
 import { buildProvider } from './tracing';
 import { schema } from './resolvers';
-import { ArchiveNodeAdapter } from './db';
+import { GraphQLContext, buildContext } from './context';
 
 let LOG_LEVEL = (process.env.LOG_LEVEL as LogLevel) || 'info';
 
@@ -26,7 +26,7 @@ export function buildServer() {
   if (process.env.ENABLE_INTROSPECTION !== 'true')
     plugins.push(useDisableIntrospection());
 
-  const yoga = createYoga({
+  const yoga = createYoga<GraphQLContext>({
     schema,
     logging: LOG_LEVEL,
     graphqlEndpoint: '/',
@@ -39,9 +39,7 @@ export function buildServer() {
       methods: ['GET'],
     },
     context: () => {
-      return {
-        db_client: new ArchiveNodeAdapter(process.env.PG_CONN),
-      };
+      return buildContext();
     },
   });
   return createServer(yoga);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import { createYoga, LogLevel } from 'graphql-yoga';
+import { createYoga, LogLevel, YogaInitialContext } from 'graphql-yoga';
 import { createServer } from 'http';
 import { useGraphQlJit } from '@envelop/graphql-jit';
 import { useDisableIntrospection } from '@envelop/disable-introspection';
@@ -44,6 +44,5 @@ export function buildServer() {
       };
     },
   });
-  const server = createServer(yoga);
-  return server;
+  return createServer(yoga);
 }


### PR DESCRIPTION
## Description
Adds a new field to the blockInfo GraphQL type. As the name suggests, it is the distance from the maximum block height for a given block. This will be useful for when a zkApp developer is trying to query for event/action data at the very tip of the network. When the distance is 0, multiple blocks can be returned as there is no good selection algorithm implemented to decide which block to return at the very tip.

Also, change some String values on the GraphQL schema to numbers since they make more sense. Additionally, make a name change to the 'fields' field on Events to be 'data' instead.

Adds a context file which exports a GraphQLContext interface and a buildContext function. Before this change, the context is passed into the resolver was being typed as `any`. This change types the context to have better type safety in our resolvers.

## Impact
Now have a GraphQL field to indicate when the event/actions data is at the current tip of the network. Additionally, there is better type of safety in the project now.

## Testing
Manually tested
![image](https://user-images.githubusercontent.com/9512405/219231192-c18dface-e69d-45dd-9e74-998ecaf72bb3.png)
