### PR TITLE
Add tracing for SQL statements and processing SQL rows

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,9 @@
+import { Span } from '@opentelemetry/tracing';
 import { ArchiveNodeAdapter, DatabaseAdapter } from './db';
 
 export interface GraphQLContext {
   db_client: DatabaseAdapter;
+  [OPEN_TELEMETRY_GRAPHQL: symbol]: Span | undefined;
 }
 
 export async function buildContext(connectionString: string | undefined) {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,8 +3,11 @@ import type { Actions, Events } from '../models/types';
 import { ArchiveNodeAdapter } from './archive-node-adapter';
 
 interface DatabaseAdapter {
-  getEvents(input: EventFilterOptionsInput): Promise<Events>;
-  getActions(input: EventFilterOptionsInput): Promise<Actions>;
+  getEvents(input: EventFilterOptionsInput, options?: unknown): Promise<Events>;
+  getActions(
+    input: EventFilterOptionsInput,
+    options?: unknown
+  ): Promise<Actions>;
 }
 
 export { DatabaseAdapter, ArchiveNodeAdapter };

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,14 +1,35 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { typeDefinitions } from './schema';
 import { Resolvers } from './resolvers-types';
+import { getTracingInfo } from './tracing';
 
 export const resolvers: Resolvers = {
   Query: {
-    events: async (_, { input }, { db_client }) => {
-      return db_client.getEvents(input);
+    events: async (_, { input }, context) => {
+      const contextSymbols = Object.getOwnPropertySymbols(context);
+      const traceInfo = getTracingInfo(context[contextSymbols?.[0]]);
+
+      if (!traceInfo) {
+        return context.db_client.getEvents(input);
+      }
+
+      const eventsData = context.db_client.getEvents(input, {
+        traceInfo,
+      });
+      return eventsData;
     },
-    actions: async (_, { input }, { db_client }) => {
-      return db_client.getActions(input);
+    actions: async (_, { input }, context) => {
+      const contextSymbols = Object.getOwnPropertySymbols(context);
+      const traceInfo = getTracingInfo(context[contextSymbols?.[0]]);
+
+      if (!traceInfo) {
+        return context.db_client.getEvents(input);
+      }
+
+      const actionsData = context.db_client.getActions(input, {
+        traceInfo,
+      });
+      return actionsData ?? [];
     },
   },
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,7 +66,7 @@ function buildPlugins() {
     plugins.push(
       useOpenTelemetry(
         {
-          resolvers: false, // Tracks resolvers calls, and tracks resolvers thrown errors
+          resolvers: true, // Tracks resolvers calls, and tracks resolvers thrown errors
           variables: true, // Includes the operation variables values as part of the metadata collected
           result: true, // Includes execution result object as part of the metadata collected
         },

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -3,6 +3,7 @@ import {
   BatchSpanProcessor,
   BasicTracerProvider,
 } from '@opentelemetry/tracing';
+import { context, trace, Span, Tracer, Context } from '@opentelemetry/api';
 
 export function buildProvider() {
   const options = {
@@ -16,4 +17,18 @@ export function buildProvider() {
   provider.addSpanProcessor(new BatchSpanProcessor(exporter));
   provider.register();
   return provider;
+}
+
+export type TraceInfo = {
+  tracer: Tracer;
+  ctx: Context;
+  parentSpan: Span;
+};
+
+export function getTracingInfo(parentSpan: Span | undefined) {
+  if (!parentSpan) return null;
+  const tracer = trace.getTracer('graphql');
+  const ctx = trace.setSpan(context.active(), parentSpan);
+
+  return { tracer, ctx, parentSpan } as TraceInfo;
 }


### PR DESCRIPTION
## Description

This PR adds specific tracing for SQL statements and processing the SQL rows. With this change, we can now get detailed information on how long each SQL statement takes to execute and how long it takes to process each row.

## Impact

This change improves the overall performance of our application by providing more detailed information about SQL statements and row processing times. It also makes diagnosing and fixing performance issues related to these operations easier. With this improved tracing capability, we can better understand how our application is interacting with the database and where we might need to optimize our queries or improve our data processing logic.

## Screenshot
This is what the new tracing looks like in Jaeger. Note that we have more fine-grained tracing for how long the SQL is taking and the GraphQL resolvers.
![image](https://user-images.githubusercontent.com/9512405/223286402-f032b9f4-44b1-4fc6-96db-fbabc31da940.png)
