### PR TITLE
Fix incorrect resolver for actions

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -14,23 +14,21 @@ export const resolvers: Resolvers = {
         return context.db_client.getEvents(input);
       }
 
-      const eventsData = context.db_client.getEvents(input, {
+      return context.db_client.getEvents(input, {
         traceInfo,
       });
-      return eventsData;
     },
     actions: async (_, { input }, context) => {
       const contextSymbols = Object.getOwnPropertySymbols(context);
       const traceInfo = getTracingInfo(context[contextSymbols?.[0]]);
 
       if (!traceInfo) {
-        return context.db_client.getEvents(input);
+        return context.db_client.getActions(input);
       }
 
-      const actionsData = context.db_client.getActions(input, {
+      return context.db_client.getActions(input, {
         traceInfo,
       });
-      return actionsData ?? [];
     },
   },
 };


### PR DESCRIPTION
In a previous PR #47, refactoring was done to add better tracing for events and actions. A bug that incorrectly called the events resolver in the actions resolver was introduced. This PR fixes that issue.