### PR TITLE
Fix event/action ordering to match network transactions

### DIFF
--- a/src/db/archive-node-adapter/index.ts
+++ b/src/db/archive-node-adapter/index.ts
@@ -88,6 +88,9 @@ export class ArchiveNodeAdapter implements DatabaseAdapter {
       blocksMap,
       elementIdFieldValues
     );
+    eventsData.sort(
+      (a, b) => Number(b.blockInfo.height) - Number(a.blockInfo.height)
+    );
     eventsProcessingSpan?.end();
     return eventsData ?? [];
   }
@@ -119,6 +122,9 @@ export class ArchiveNodeAdapter implements DatabaseAdapter {
     const actionsData = this.deriveActionsFromBlocks(
       blocksMap,
       elementIdFieldValues
+    );
+    actionsData.sort(
+      (a, b) => Number(b.blockInfo.height) - Number(a.blockInfo.height)
     );
     actionsProcessingSpan?.end();
     return actionsData ?? [];
@@ -178,7 +184,6 @@ export class ArchiveNodeAdapter implements DatabaseAdapter {
         filteredBlocks,
         elementIdFieldValues
       ) as Event[];
-
       events.sort((a, b) => Number(a.index) - Number(b.index));
       eventsData.push({ blockInfo, transactionInfo, eventData: events });
     }
@@ -227,8 +232,6 @@ export class ArchiveNodeAdapter implements DatabaseAdapter {
         blocks,
         elementIdFieldValues
       ) as Action[];
-
-      actions.reverse();
       actionsData.push({ blockInfo, transactionInfo, actionData: actions });
     }
     return actionsData;

--- a/src/db/archive-node-adapter/queries.ts
+++ b/src/db/archive-node-adapter/queries.ts
@@ -137,7 +137,6 @@ export function getEventsQuery(
   ${emittedEventsCTE(db_client)}
   SELECT *
   FROM emitted_events
-  ORDER BY timestamp DESC, state_hash DESC
   `;
 }
 
@@ -158,7 +157,6 @@ export function getActionsQuery(
   ${emittedActionsCTE(db_client)}
   SELECT *
   FROM emitted_actions
-  ORDER BY timestamp DESC, state_hash DESC
   `;
 }
 


### PR DESCRIPTION
Addresses #50 

The ordering of the returning SQL rows was being mixed incorrectly due to the ORDER BY statement. Removed the ORDER BY statement and did the sorting of blocks in TypeScript instead. The performance hit is negligible so there's no sort of trade-off.