### PR TITLE
Remove index from GraphQL schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -13,7 +13,6 @@ input EventFilterOptionsInput {
 }
 
 type EventData {
-  index: String!
   data: [String]!
 }
 

--- a/src/db/archive-node-adapter/index.ts
+++ b/src/db/archive-node-adapter/index.ts
@@ -110,8 +110,6 @@ export class ArchiveNodeAdapter implements DatabaseAdapter {
       traceInfo.ctx
     );
     const rows = await this.executeActionsQuery(input);
-    console.log(rows);
-
     sqlSpan?.end();
 
     const actionsProcessingSpan = traceInfo?.tracer.startSpan(

--- a/src/db/archive-node-adapter/index.ts
+++ b/src/db/archive-node-adapter/index.ts
@@ -184,7 +184,9 @@ export class ArchiveNodeAdapter implements DatabaseAdapter {
         filteredBlocks,
         elementIdFieldValues
       ) as Event[];
-      events.sort((a, b) => Number(a.index) - Number(b.index));
+      if (events.every((event) => event.data.length >= 2)) {
+        events.sort((a, b) => Number(a.data[0]) - Number(b.data[0]));
+      }
       eventsData.push({ blockInfo, transactionInfo, eventData: events });
     }
     return eventsData;
@@ -271,7 +273,7 @@ export class ArchiveNodeAdapter implements DatabaseAdapter {
       }
 
       if (kind === 'event') {
-        const event = createEvent(currentValue[0], currentValue.slice(1));
+        const event = createEvent(currentValue);
         data.push(event);
       } else {
         const action = createAction(currentValue);

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -8,7 +8,6 @@ export enum BlockStatusFilter {
 }
 
 export type Event = {
-  index: string;
   data: string[];
 };
 

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -24,9 +24,8 @@ export function createTransactionInfo(row: postgres.Row) {
   } as TransactionInfo;
 }
 
-export function createEvent(index: string, data: string[]) {
+export function createEvent(data: string[]) {
   return {
-    index,
     data,
   } as Event;
 }

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -57,7 +57,6 @@ export { BlockStatusFilter };
 export type EventData = {
   __typename?: 'EventData';
   data: Array<Maybe<Scalars['String']>>;
-  index: Scalars['String'];
 };
 
 export type EventFilterOptionsInput = {
@@ -309,7 +308,6 @@ export type EventDataResolvers<
     ParentType,
     ContextType
   >;
-  index?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/tests/archive-node-adapter.test.ts
+++ b/tests/archive-node-adapter.test.ts
@@ -127,7 +127,6 @@ describe('ArchiveNodeAdapter', async () => {
 
         expect(events.length).toBeTruthy();
         events.forEach((event) => {
-          expect(event).toHaveProperty('index');
           expect(event).toHaveProperty('data');
         });
       });
@@ -249,7 +248,7 @@ describe('ArchiveNodeAdapter', async () => {
         );
 
         eventsData.forEach((event) => {
-          const indexes = event.eventData.map((event) => event.index);
+          const indexes = event.eventData.map((event) => event.data[0]);
           expect(indexes).toEqual(indexes.sort());
         });
       });

--- a/tests/resolvers.test.ts
+++ b/tests/resolvers.test.ts
@@ -26,7 +26,6 @@ query getEvents($input: EventFilterOptionsInput!) {
       memo
     }
     eventData {
-      index
       data
     }
   }


### PR DESCRIPTION
## Description

If a zkApp only stores one event type, an index is not stored in the Archive Node to save space. With the possibility of a zkApp having an index or not having an index, it's simpler just to remove the index property and use the data property to hold an index if it's available. The logic in SnarkyJS already does this assumption where if there is only a single index type, it will treat the data property as only the field element.