### PR TITLE
Add actionState field to Actions resolver

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -50,6 +50,7 @@ type ActionOutput {
   blockInfo: BlockInfo
   transactionInfo: TransactionInfo
   actionData: [ActionData]
+  actionState: String!
 }
 
 type Query {

--- a/src/db/archive-node-adapter/index.ts
+++ b/src/db/archive-node-adapter/index.ts
@@ -110,6 +110,8 @@ export class ArchiveNodeAdapter implements DatabaseAdapter {
       traceInfo.ctx
     );
     const rows = await this.executeActionsQuery(input);
+    console.log(rows);
+
     sqlSpan?.end();
 
     const actionsProcessingSpan = traceInfo?.tracer.startSpan(

--- a/src/db/archive-node-adapter/index.ts
+++ b/src/db/archive-node-adapter/index.ts
@@ -227,6 +227,7 @@ export class ArchiveNodeAdapter implements DatabaseAdapter {
   ) {
     const actionsData: Actions = [];
     for (const [, blocks] of blocksMap) {
+      const { action_state_value } = blocks[0];
       const blockInfo = createBlockInfo(blocks[0]);
       const transactionInfo = createTransactionInfo(blocks[0]);
       const actions = this.mapActionOrEvent(
@@ -234,7 +235,12 @@ export class ArchiveNodeAdapter implements DatabaseAdapter {
         blocks,
         elementIdFieldValues
       ) as Action[];
-      actionsData.push({ blockInfo, transactionInfo, actionData: actions });
+      actionsData.push({
+        blockInfo,
+        transactionInfo,
+        actionData: actions,
+        actionState: action_state_value,
+      });
     }
     return actionsData;
   }

--- a/src/db/archive-node-adapter/queries.ts
+++ b/src/db/archive-node-adapter/queries.ts
@@ -120,36 +120,20 @@ function emittedActionsCTE(db_client: postgres.Sql) {
   )`;
 }
 
+// TODO: Rename sequence_states to action_states when archive node is redeployed
+// https://github.com/o1-labs/Archive-Node-API/issues/56
 function emittedActionStateCTE(db_client: postgres.Sql) {
   return db_client`
   emitted_action_state AS
   (
-    SELECT 
-      zkvh.value AS verification_key_hash, 
-
-      zkvk.verification_key AS zkapp_verification_key,
-      
-      element0,
-      zkf.field AS action_state_field,
-
-      emitted_actions.* 
-
+    SELECT zkf.field AS action_state_value, emitted_actions.*
     FROM emitted_actions
-    INNER JOIN zkapp_verification_key_hashes zkvh
-    ON zkvh.id = verification_key_hash_id
-
-    INNER JOIN zkapp_verification_keys zkvk
-    ON zkvk.hash_id = zkvh.id
-
-    INNER JOIN zkapp_accounts zka
-    ON zka.verification_key_id = zkvk.hash_id
-
+    INNER JOIN zkapp_accounts zkacc
+    ON zkacc.id = emitted_actions.zkapp_id
     INNER JOIN zkapp_sequence_states zks
-    ON zks.id = zka.sequence_state_id
-
+    ON zks.id = zkacc.sequence_state_id
     INNER JOIN zkapp_field zkf
-    ON zkf.id = element0
-
+    ON zkf.id = zks.element0
   )`;
 }
 
@@ -213,4 +197,6 @@ export const USED_TABLES = [
   'zkapp_field',
   'zkapp_verification_key_hashes',
   'zkapp_verification_keys',
+  'zkapp_accounts',
+  'zkapp_sequence_states',
 ] as const;

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -42,6 +42,7 @@ export type Events = {
 }[];
 
 export type Actions = {
+  actionState: string;
   actionData: Action[];
   blockInfo: BlockInfo;
   transactionInfo: TransactionInfo;

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -35,6 +35,7 @@ export type ActionData = {
 export type ActionOutput = {
   __typename?: 'ActionOutput';
   actionData?: Maybe<Array<Maybe<ActionData>>>;
+  actionState: Scalars['String'];
   blockInfo?: Maybe<BlockInfo>;
   transactionInfo?: Maybe<TransactionInfo>;
 };
@@ -254,6 +255,7 @@ export type ActionOutputResolvers<
     ParentType,
     ContextType
   >;
+  actionState?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   blockInfo?: Resolver<
     Maybe<ResolversTypes['BlockInfo']>,
     ParentType,

--- a/tests/resolvers.test.ts
+++ b/tests/resolvers.test.ts
@@ -44,6 +44,7 @@ query getEvents($input: EventFilterOptionsInput!) {
       chainStatus
       distanceFromMaxBlockHeight
     }
+    actionState
     transactionInfo {
       status
       hash


### PR DESCRIPTION
## Description

To integrate actions into SnarkyJS, we need the actionState of an applied account update. We only fetch the most recent actionHash from the Archive Node DB since other hashes at any point in time might reflect an older state with some actions not included. 