### PR TITLE
Fix queries used in benchmarks

### DIFF
--- a/benchmark/graphql.yaml
+++ b/benchmark/graphql.yaml
@@ -44,7 +44,6 @@ scenarios:
                     memo
                   }
                   eventData {
-                    index
                     data
                   }
                 }
@@ -79,6 +78,7 @@ scenarios:
                     hash
                     memo
                   }
+                  actionState
                   actionData {
                     data
                   }


### PR DESCRIPTION
Fix the queries used in the benchmarks module to use the new `actionState` resolver on the actions query and to remove the index resolver on the events query.