### PR TITLE
Fix duplicated events/actions from queries

### DIFF
--- a/src/db/archive-node-adapter/index.ts
+++ b/src/db/archive-node-adapter/index.ts
@@ -209,6 +209,7 @@ export class ArchiveNodeAdapter implements DatabaseAdapter {
           continue;
         } else {
           seenEventIds.set(uniqueElementIdsKey, numberofUniqueElements + 1);
+          continue;
         }
       }
       // If all the element ids are the same, there will only be one returned row, so we do not have to do any filtering.

--- a/src/db/archive-node-adapter/queries.ts
+++ b/src/db/archive-node-adapter/queries.ts
@@ -17,7 +17,7 @@ function fullChainCTE(db_client: postgres.Sql) {
     AND pending_chain.chain_status <> 'canonical'
   ), 
   full_chain AS (
-    SELECT id, state_hash, parent_id, parent_hash, height, global_slot_since_genesis, global_slot_since_hard_fork, timestamp, chain_status, ledger_hash, (SELECT max(height) FROM blocks) - height AS distance_from_max_block_height
+    SELECT DISTINCT id, state_hash, parent_id, parent_hash, height, global_slot_since_genesis, global_slot_since_hard_fork, timestamp, chain_status, ledger_hash, (SELECT max(height) FROM blocks) - height AS distance_from_max_block_height
     FROM 
       (
         SELECT id, state_hash, parent_id, parent_hash, height, global_slot_since_genesis, global_slot_since_hard_fork, timestamp, chain_status, ledger_hash 


### PR DESCRIPTION
## Description

During testing, it was found that there would sometimes be duplicate events/actions being returned from the Archive Node API. This PR aims to fix the issue by addressing existing bugs.

1. The blocks SQL CTE was incorrect and was reporting duplicate blocks. This was solved by adding the `DISTINCT` keyword, which forces the SQL query only to return distinct rows for each block height.
2. Fix the `filterDuplicateBlocks` method to correctly skip over adding a block if it's already been seen. In some cases, blocks were being incorrectly added if they were already seen and marked to be filtered out. Add a `continue` so that we do not add duplicate block data, which results in duplicate events.