### PR TITLE
Fix graphql schema to support different zkApp transactions within a block

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -13,11 +13,13 @@ input EventFilterOptionsInput {
 }
 
 type EventData {
+  transactionInfo: TransactionInfo
   data: [String]!
 }
 
 type ActionData {
   accountUpdateId: String!
+  transactionInfo: TransactionInfo
   data: [String]!
 }
 
@@ -42,7 +44,6 @@ type TransactionInfo {
 
 type EventOutput {
   blockInfo: BlockInfo
-  transactionInfo: TransactionInfo
   eventData: [EventData]
 }
 

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -8,11 +8,13 @@ export enum BlockStatusFilter {
 }
 
 export type Event = {
+  transactionInfo: TransactionInfo;
   data: string[];
 };
 
 export type Action = {
   accountUpdateId: string;
+  transactionInfo: TransactionInfo;
   data: string[];
 };
 
@@ -38,14 +40,12 @@ export type TransactionInfo = {
 export type Events = {
   eventData: Event[];
   blockInfo: BlockInfo;
-  transactionInfo: TransactionInfo;
 }[];
 
 export type Actions = {
   actionState: string;
   actionData: Action[];
   blockInfo: BlockInfo;
-  transactionInfo: TransactionInfo;
 }[];
 
 export type ArchiveNodeDatabaseRow = {

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -24,15 +24,21 @@ export function createTransactionInfo(row: postgres.Row) {
   } as TransactionInfo;
 }
 
-export function createEvent(data: string[]) {
+export function createEvent(data: string[], transactionInfo: TransactionInfo) {
   return {
     data,
+    transactionInfo,
   } as Event;
 }
 
-export function createAction(accountUpdateId: string, data: string[]) {
+export function createAction(
+  accountUpdateId: string,
+  data: string[],
+  transactionInfo: TransactionInfo
+) {
   return {
     accountUpdateId,
     data,
+    transactionInfo,
   } as Action;
 }

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -31,6 +31,7 @@ export type ActionData = {
   __typename?: 'ActionData';
   accountUpdateId: Scalars['String'];
   data: Array<Maybe<Scalars['String']>>;
+  transactionInfo?: Maybe<TransactionInfo>;
 };
 
 export type ActionOutput = {
@@ -59,6 +60,7 @@ export { BlockStatusFilter };
 export type EventData = {
   __typename?: 'EventData';
   data: Array<Maybe<Scalars['String']>>;
+  transactionInfo?: Maybe<TransactionInfo>;
 };
 
 export type EventFilterOptionsInput = {
@@ -73,7 +75,6 @@ export type EventOutput = {
   __typename?: 'EventOutput';
   blockInfo?: Maybe<BlockInfo>;
   eventData?: Maybe<Array<Maybe<EventData>>>;
-  transactionInfo?: Maybe<TransactionInfo>;
 };
 
 export type Query = {
@@ -244,6 +245,11 @@ export type ActionDataResolvers<
     ParentType,
     ContextType
   >;
+  transactionInfo?: Resolver<
+    Maybe<ResolversTypes['TransactionInfo']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -312,6 +318,11 @@ export type EventDataResolvers<
     ParentType,
     ContextType
   >;
+  transactionInfo?: Resolver<
+    Maybe<ResolversTypes['TransactionInfo']>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -326,11 +337,6 @@ export type EventOutputResolvers<
   >;
   eventData?: Resolver<
     Maybe<Array<Maybe<ResolversTypes['EventData']>>>,
-    ParentType,
-    ContextType
-  >;
-  transactionInfo?: Resolver<
-    Maybe<ResolversTypes['TransactionInfo']>,
     ParentType,
     ContextType
   >;

--- a/tests/resolvers.test.ts
+++ b/tests/resolvers.test.ts
@@ -20,12 +20,12 @@ query getEvents($input: EventFilterOptionsInput!) {
       chainStatus
       distanceFromMaxBlockHeight
     }
-    transactionInfo {
-      status
-      hash
-      memo
-    }
     eventData {
+      transactionInfo {
+        status
+        hash
+        memo
+      }
       data
     }
   }
@@ -44,12 +44,12 @@ query getEvents($input: EventFilterOptionsInput!) {
       distanceFromMaxBlockHeight
     }
     actionState
-    transactionInfo {
-      status
-      hash
-      memo
-    }
     actionData {
+      transactionInfo {
+       status
+       hash
+       memo
+      }
       data
     }
   }


### PR DESCRIPTION
## Description

Since there can be multiple zkApp transactions within a block, assuming that events/actions will be under the duplicate zkApp transactions within a block is always wrong. We change the schema here to support different zkApp transactions with event/action data within the same block.