### PR TITLE
Fix the block sorting to make sure it's always in descending order

### DIFF
--- a/src/services/data-adapters/database-row-adapters.ts
+++ b/src/services/data-adapters/database-row-adapters.ts
@@ -237,10 +237,14 @@ function getFieldValuesFromElementIds(
 
 function sortAndFilterBlocks<T extends { blockInfo: BlockInfo }>(data: T[]) {
   data.sort((a, b) => {
-    if (a.blockInfo.height < b.blockInfo.height) return -1;
-    if (a.blockInfo.height > b.blockInfo.height) return 1;
+    // Sort by height in descending order
+    if (a.blockInfo.height > b.blockInfo.height) return -1;
+    if (a.blockInfo.height < b.blockInfo.height) return 1;
+
+    // If heights are equal, sort by timestamp (assuming ascending order)
     if (a.blockInfo.timestamp < b.blockInfo.timestamp) return -1;
     if (a.blockInfo.timestamp > b.blockInfo.timestamp) return 1;
+
     return 0;
   });
   filterBestTip(data);


### PR DESCRIPTION
The sorting logic for returned blocks was incorrect; this fixes the sorting to be in descending order instead.