### PR TITLE
fix(mina-consensus.ts): correct the splice index in filterBestTip

### DIFF
--- a/src/consensus/mina-consensus.ts
+++ b/src/consensus/mina-consensus.ts
@@ -24,7 +24,12 @@ function filterBestTip<T extends { blockInfo: BlockInfo }>(
   );
   if (highestTipBlocks.length > 1) {
     const selectedBlock = chainSelect(highestTipBlocks);
-    eventOrActionData.splice(0, highestTipBlocks.length + 1, selectedBlock);
+    const startIndex = eventOrActionData.length - highestTipBlocks.length;
+    eventOrActionData.splice(
+      startIndex,
+      highestTipBlocks.length,
+      selectedBlock
+    );
   }
 }
 


### PR DESCRIPTION
The previous implementation was incorrectly splicing from the start of the array, which could lead to unexpected results. The fix ensures that the splice operation starts from the correct index, preserving the integrity of the array.