### PR TITLE
Bump version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "archive-node-graphql",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A NodeJS GraphQL server for exposing data for o1js/zkApps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR is in preparation to release v1.1.0

I have tested it against my own copy of the devnet archive DB and it works with the current version of o1js (no regressions).  It will also enable us to access the required sorting information in future versions of o1js.

Note: it is actually Minascan who run the only devnet archive node API and I have confirmed with them that they are ready to run the new version when it's released.