### PR TITLE
Filter pending blocks as well as canonical

### DIFF
--- a/src/db/sql/events-actions/queries.ts
+++ b/src/db/sql/events-actions/queries.ts
@@ -12,8 +12,6 @@ function fullChainCTE(db_client: postgres.Sql, from?: string, to?: string) {
   } else if (toAsNum) {
     fromAsNum = toAsNum - BLOCK_RANGE_SIZE;
   }
-  console.log('fromAsNum', fromAsNum);
-  console.log('toAsNum', toAsNum);
   return db_client`
   RECURSIVE pending_chain AS (
     (


### PR DESCRIPTION
This PR applies the block height filter to the pending blocks as well as canonical.

Currently, if a user filters for actions from blocks a to b, they will get those _plus_ all actions that are in pending blocks, regardless of their block height.

We should filter the canonical and the pending chains so that users who make a specific request get only the data they asked for.  In the default case, there is no difference since the last `n` blocks will aways included the pending chain.

OLD:
![image](https://github.com/user-attachments/assets/f0372050-24cc-44c2-992b-46a0d18f7053)

NEW: 
![image](https://github.com/user-attachments/assets/56cb621b-1741-4d9a-bfb9-aaf9787e5e2b)
![image](https://github.com/user-attachments/assets/044a5a39-cf6f-4f4f-b583-24bc57db448f)


