### PR TITLE
handle hourly files in the download script

### DIFF
--- a/scripts/download_db.sh
+++ b/scripts/download_db.sh
@@ -90,5 +90,5 @@ for i in $(seq 0 2); do
   fi
 done
 
-echo "No valid dump found for network=$NETWORK in the last 10 days"
+echo "No valid dump found for network=$NETWORK in the last 3 days"
 exit 1

--- a/scripts/download_db.sh
+++ b/scripts/download_db.sh
@@ -30,18 +30,50 @@ cd "$DATA_DIR"
 
 # get date as YYYY-MM-DD
 get_date() {
+  local offset=${1:-0}
   # macOS
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    date -v -"$1"d '+%Y-%m-%d'    
+    date -u -v -"$offset"d '+%Y-%m-%d'
   # linux
   else
-    date -d "-$1 days" '+%Y-%m-%d'
+    date -u -d "-$offset days" '+%Y-%m-%d'
+  fi
+}
+
+# get most recent GMT hour as HHMM
+get_hour() {
+  local offset=${1:-0}
+  # macOS
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    date -u -v -"$offset"H '+%H00'
+  # linux
+  else
+    date -u -d "-$offset hours" '+%H00'
   fi
 }
 
 
-# look for most recent db dump up to 10 days old
-for i in $(seq 0 9); do
+# Look for the most recent archive node DB dump from the last 3 hours
+for i in $(seq 0 2); do
+  DATE=$(get_date)
+  HOUR=$(get_hour "$i")
+  FILE="${NETWORK}-archive-dump-${DATE}_${HOUR}.sql.tar.gz"
+  URL="${BASE_URL}/${FILE}"
+
+  echo "Attempting to download archive node DB dump from: $URL"
+
+  # abort download if the file is an XML error page
+  if curl -sf -O "$URL" && ! grep -q "<Error>" "$FILE"; then
+    tar -xf "$FILE"
+    mv "${FILE%.tar.gz}" "$PG_DUMP"
+    rm "$FILE"
+    echo "Downloaded and extracted to $DATA_DIR/$PG_DUMP"
+    exit 0
+  fi
+done
+
+# If not found, try the last 3 days at 00:00
+for i in $(seq 0 2); do
   DATE=$(get_date "$i")
   FILE="${NETWORK}-archive-dump-${DATE}_0000.sql.tar.gz"
   URL="${BASE_URL}/${FILE}"

--- a/scripts/download_db.sh
+++ b/scripts/download_db.sh
@@ -63,7 +63,7 @@ for i in $(seq 0 2); do
   echo "Attempting to download archive node DB dump from: $URL"
 
   # abort download if the file is an XML error page
-  if curl -sf -O "$URL" && ! grep -q "<Error>" "$FILE"; then
+  if curl -# -O "$URL" && ! grep -q "<Error>" "$FILE"; then
     tar -xf "$FILE"
     mv "${FILE%.tar.gz}" "$PG_DUMP"
     rm "$FILE"
@@ -81,7 +81,7 @@ for i in $(seq 0 2); do
   echo "Attempting to download archive node DB dump from: $URL"
 
   # abort download if the file is an XML error page
-  if curl -sf -O "$URL" && ! grep -q "<Error>" "$FILE"; then
+  if curl -# -O "$URL" && ! grep -q "<Error>" "$FILE"; then
     tar -xf "$FILE"
     mv "${FILE%.tar.gz}" "$PG_DUMP"
     rm "$FILE"


### PR DESCRIPTION
I talked with @SanabriaRusso and he was able to trigger the data dump job hourly instead of daily.  So this PR updates the download data script to look for the most recent hourly dump.

If the last 3 hours are missing, it falls back to checking the last 3 days at `0000`, which was the old format.