### PR TITLE
Add parentHash field to Block type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,7 @@ benchmark/*.csv
  
 # docker-compose postgres volumes
 db/   
-data/   
+data/
+
+# memsearch
+.memsearch/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mina-archive-node-graphql",
-  "version": "0.0.8",
+  "name": "@o1-labs/mina-archive-node-graphql",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mina-archive-node-graphql",
-      "version": "0.0.8",
+      "name": "@o1-labs/mina-archive-node-graphql",
+      "version": "0.0.5",
       "license": "ISC",
       "dependencies": {
         "@envelop/core": "^4.0.0",
@@ -25,6 +25,9 @@
         "graphql": "^16.8.0",
         "graphql-yoga": "4.0.4",
         "postgres": "^3.3.5"
+      },
+      "bin": {
+        "mina-archive-node-graphql": "build/src/index.js"
       },
       "devDependencies": {
         "@graphql-codegen/cli": "^6.0.1",

--- a/schema.graphql
+++ b/schema.graphql
@@ -208,6 +208,7 @@ type Block {
   blockHeight: Int!
   creator: String!
   stateHash: String!
+  parentHash: String!
   dateTime: DateTime!
   transactions: BlockTransactions!
 }

--- a/src/blockchain/types.ts
+++ b/src/blockchain/types.ts
@@ -113,6 +113,7 @@ export type Block = {
   blockHeight: number;
   creator: string;
   stateHash: string;
+  parentHash: string;
   dateTime: string;
   transactions: BlockTransactions;
 };

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -90,6 +90,7 @@ export type Block = {
   blockHeight: Scalars['Int']['output'];
   creator: Scalars['String']['output'];
   dateTime: Scalars['DateTime']['output'];
+  parentHash: Scalars['String']['output'];
   stateHash: Scalars['String']['output'];
   transactions: BlockTransactions;
 };
@@ -499,6 +500,7 @@ export type BlockResolvers<
   blockHeight?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   creator?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   dateTime?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  parentHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   stateHash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   transactions?: Resolver<
     ResolversTypes['BlockTransactions'],

--- a/src/services/blocks-service/blocks-service.ts
+++ b/src/services/blocks-service/blocks-service.ts
@@ -394,7 +394,7 @@ class BlocksService implements IBlocksService {
       blockHeight: row.height,
       creator: row.creator,
       stateHash: row.state_hash,
-      parentHash: row.parent_hash,
+      parentHash: ENABLE_BLOCK_TRANSACTION_DETAILS ? row.parent_hash : '',
       dateTime: new Date(parseInt(row.timestamp)).toISOString(),
       transactions: {
         coinbase: row.coinbase_amount || '0',

--- a/src/services/blocks-service/blocks-service.ts
+++ b/src/services/blocks-service/blocks-service.ts
@@ -28,6 +28,7 @@ interface BlockRow {
   height: number;
   creator: string;
   state_hash: string;
+  parent_hash: string;
   timestamp: string;
   internal_command_type?: string;
   coinbase_amount?: string;
@@ -136,6 +137,7 @@ class BlocksService implements IBlocksService {
       SELECT
         b.id,
         b.state_hash,
+        b.parent_hash,
         b.height,
         b.timestamp,
         pk.value as creator,
@@ -392,6 +394,7 @@ class BlocksService implements IBlocksService {
       blockHeight: row.height,
       creator: row.creator,
       stateHash: row.state_hash,
+      parentHash: row.parent_hash,
       dateTime: new Date(parseInt(row.timestamp)).toISOString(),
       transactions: {
         coinbase: row.coinbase_amount || '0',

--- a/tests/services/blocks-service/blocks-service.test.ts
+++ b/tests/services/blocks-service/blocks-service.test.ts
@@ -37,7 +37,7 @@ describe('BlocksService', () => {
       assert.strictEqual(blocks[0].blockHeight, 100);
       assert.strictEqual(blocks[0].creator, 'B62qtest1');
       assert.strictEqual(blocks[0].stateHash, '3NKtest1');
-      assert.strictEqual(blocks[0].parentHash, '3NKparent1');
+      assert.strictEqual(blocks[0].parentHash, '');
       assert.strictEqual(
         blocks[0].dateTime,
         new Date(1700000000000).toISOString()

--- a/tests/services/blocks-service/blocks-service.test.ts
+++ b/tests/services/blocks-service/blocks-service.test.ts
@@ -26,6 +26,7 @@ describe('BlocksService', () => {
       height: 100,
       creator: 'B62qtest1',
       state_hash: '3NKtest1',
+      parent_hash: '3NKparent1',
       timestamp: '1700000000000',
       coinbase_amount: '720000000000',
     };
@@ -36,6 +37,7 @@ describe('BlocksService', () => {
       assert.strictEqual(blocks[0].blockHeight, 100);
       assert.strictEqual(blocks[0].creator, 'B62qtest1');
       assert.strictEqual(blocks[0].stateHash, '3NKtest1');
+      assert.strictEqual(blocks[0].parentHash, '3NKparent1');
       assert.strictEqual(
         blocks[0].dateTime,
         new Date(1700000000000).toISOString()
@@ -389,8 +391,8 @@ describe('BlocksService', () => {
       );
 
       const blockRows = [
-        { id: 10, height: 500, creator: 'B62qCreator1', state_hash: '3NK1', timestamp: '1700000000000', coinbase_amount: '720000000000' },
-        { id: 20, height: 501, creator: 'B62qCreator2', state_hash: '3NK2', timestamp: '1700000060000', coinbase_amount: '720000000000' },
+        { id: 10, height: 500, creator: 'B62qCreator1', state_hash: '3NK1', parent_hash: '3NKp1', timestamp: '1700000000000', coinbase_amount: '720000000000' },
+        { id: 20, height: 501, creator: 'B62qCreator2', state_hash: '3NK2', parent_hash: '3NKp2', timestamp: '1700000060000', coinbase_amount: '720000000000' },
       ];
 
       const blocks = service.rowsToBlocks(blockRows, ucMap);


### PR DESCRIPTION
Expose the existing blocks.parent_hash column through the GraphQL Block type so consumers (e.g. mina-explorer) can display and link to parent blocks

This helped resolve https://github.com/o1-labs/mina-explorer/issues/41