### PR TITLE
Add shebang so the bin entry is actually executable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { buildContext } from './context.js';
 import { buildServer } from './server/server.js';
 import { buildPlugins } from './server/plugins.js';


### PR DESCRIPTION
## Summary
- The package already declares `"bin": { "mina-archive-node-graphql": "build/src/index.js" }` in `package.json`, but `src/index.ts` has no `#!/usr/bin/env node` shebang.
- After `tsc` compiles, `build/src/index.js` has no interpreter line either, so the symlink npm creates for the bin entry fails with `exec format error` when invoked directly (`npx mina-archive-node-graphql`, or after `npm install -g`).
- Fix: add `#!/usr/bin/env node` at the top of `src/index.ts`. TypeScript preserves a leading shebang through compilation, so no build-script change is needed.

## Why it matters
Downstream consumers currently have to work around this. For example, [`mina-lightnet-docker`](https://github.com/o1-labs/mina-lightnet-docker/blob/main/scripts/spinup-testnet.sh) launches the server as:

\`\`\`sh
node /usr/lib/node_modules/mina-archive-node-graphql/build/src/index.js
\`\`\`

With this fix, once a version carrying the shebang is published, that line collapses to:

\`\`\`sh
mina-archive-node-graphql
\`\`\`

Same benefit for anyone running \`npx @o1-labs/mina-archive-node-graphql\` or scripting around the package in a larger container.

## Test plan
- [x] \`npm ci && npm run build\` succeeds
- [x] Verified \`head -1 build/src/index.js\` is \`#!/usr/bin/env node\`
- [ ] After a release is cut, confirm \`npx @o1-labs/mina-archive-node-graphql\` runs without \`exec format error\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)