### PR TITLE
Release 0.0.6: bump version and enable first-time public scoped publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -26,4 +26,4 @@ jobs:
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test
-      - run: npm publish --provenance
+      - run: npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@o1-labs/mina-archive-node-graphql",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A NodeJS GraphQL server for exposing Mina Protocol archive node data for o1js/zkApps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Prepares the first public release of `@o1-labs/mina-archive-node-graphql` under the new scoped name. Two minimal changes:

1. **`package.json`**: version `0.0.5` → `0.0.6`. This release carries the shebang fix from #152, so the `mina-archive-node-graphql` bin symlink is finally executable after `npm install -g`.

2. **`.github/workflows/publish-npm.yml`**: `npm publish --provenance` → `npm publish --provenance --access public`. The package has been renamed from the unscoped `mina-archive-node-graphql` (owned by an individual npm account) to the scoped `@o1-labs/mina-archive-node-graphql`, which has never been published under this name. For a scoped package's first publish, npm defaults to `restricted` access and aborts for accounts without a paid plan, so we must opt into public explicitly. The flag is harmless on subsequent publishes.

## Release process after merge

1. Merge this PR.
2. Tag and push:
   ```sh
   git tag v0.0.6
   git push origin v0.0.6
   ```
3. The tag push triggers `publish-npm.yml`, which runs `npm publish --provenance --access public`.
4. Verify on public npm:
   ```sh
   npm view @o1-labs/mina-archive-node-graphql version
   # should print 0.0.6
   ```

## Preconditions (already met per @dkijania)

- [x] `@o1-labs` user/org exists on npmjs.com with publish credentials
- [ ] (if OIDC) trusted-publisher config on npmjs.com pointing at `o1-labs/Archive-Node-API` → `.github/workflows/publish-npm.yml` — **please verify this is set up, otherwise the publish will fail with an auth error and we'll need to add an `NPM_TOKEN` secret as a fallback**

## Follow-up (not in this PR)

- Update [`mina-lightnet-docker`](https://github.com/o1-labs/mina-lightnet-docker) Dockerfile: rename the package from `mina-archive-node-graphql` to `@o1-labs/mina-archive-node-graphql`, bump version to `0.0.6`, and collapse the launch line from `node /usr/lib/node_modules/.../build/src/index.js` to just `mina-archive-node-graphql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)