### PR TITLE
ci(publish): add mina-local-network service so npm test passes

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,6 +13,18 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    services:
+      mina-local-network:
+        image: o1labs/mina-local-network:compatible-latest-lightnet
+        env:
+          NETWORK_TYPE: 'single-node'
+          PROOF_LEVEL: 'none'
+        ports:
+          - 3085:3085
+          - 5432:5432
+          - 8080:8080
+          - 8181:8181
+          - 8282:8282
     steps:
       - uses: actions/checkout@v4
 
@@ -25,5 +37,13 @@ jobs:
         run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build --if-present
+
+      - name: Wait for Mina network readiness
+        uses: o1-labs/wait-for-mina-network-action@v1
+        with:
+          mina-graphql-port: 8080
+          max-attempts: 60
+          polling-interval-ms: 10000
+
       - run: npm test
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Adds the `mina-local-network` service block + `wait-for-mina-network-action` step to `publish-npm.yml`, mirroring `run-tests.yaml`
- Fixes the publish failure that hit `v0.0.6` (run [25001081251](https://github.com/o1-labs/Archive-Node-API/actions/runs/25001081251)) and the earlier `v0.0.8` attempt
- Keeps the `npm test` step as-is — no tests disabled or skipped

## Why

The publish workflow runs `npm test`, which runs integration tests. Those tests connect to a Postgres on port 5432 and a Mina GraphQL on 8080. The PR/main test workflow (`run-tests.yaml`) starts a `mina-local-network` Docker service that exposes both ports; `publish-npm.yml` had no such service, so the integration tests died with `ECONNREFUSED` and the `after` hook crashed with `TypeError: Cannot read properties of undefined (reading 'end')` while trying to close a connection that was never opened. The publish step itself never executed.

This is structural, not a flake — every tag push fails the same way until the asymmetry is fixed.

## Test plan

- [ ] Merge this PR
- [ ] Manually dispatch the publish workflow against `main`:
  ```sh
  gh workflow run publish-npm.yml --repo o1-labs/Archive-Node-API --ref main
  ```
- [ ] Confirm the workflow reaches and completes the `npm publish` step
- [ ] Verify on registry: `npm view @o1-labs/mina-archive-node-graphql version`

## Notes

If `0.0.6` ends up being published manually before this PR merges (to unblock docs), the post-merge dispatch will fail at `npm publish` with a 403 because the version is immutable. In that case, bump to `0.0.7` in a follow-up and dispatch again — the rest of this fix is still correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)