### PR TITLE
P1: Harden Docker image — tini PID 1, HEALTHCHECK, pinned digest (#171)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+build
+coverage
+.git
+.github
+.memsearch
+db
+data
+*.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@ coverage
 .git
 .github
 .memsearch
+.env*
 db
 data
 *.log

--- a/.env.example.compose
+++ b/.env.example.compose
@@ -26,7 +26,6 @@ PGPORT=5432 # Local port for postgres - it will always be 5432 inside the contai
 JAEGER=jaegertracing/all-in-one:latest
 
 # Fields for App (Required)
-APP_COMMAND="npm run start"
 PORT=8080
 LOG_LEVEL="info"
 CORS_ORIGIN="*"

--- a/.env.example.lightnet
+++ b/.env.example.lightnet
@@ -1,4 +1,3 @@
-APP_COMMAND="npm run start"
 PORT=8080
 LOG_LEVEL="info"
 CORS_ORIGIN="*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Stage 1: Build the TypeScript code
-FROM node:20-alpine AS build
+# Base image pinned by digest for reproducible, tamper-evident builds (node:20-alpine).
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -7,19 +8,31 @@ COPY src ./src
 COPY tsconfig.json ./
 RUN npm run build
 
-# Stage 2: Copy the built code and the node modules
-FROM node:20-alpine
+# Stage 2: Runtime
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
 WORKDIR /app
+
+# tini as PID 1: forwards SIGTERM to node (so graceful shutdown runs) and reaps zombies.
+RUN apk add --no-cache tini
+
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/build ./build
 COPY package*.json ./
 COPY schema.graphql ./
 
 # Don't run as root
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nodeuser -u 1001
-RUN chown -R nodeuser:nodejs /app
+RUN addgroup -g 1001 -S nodejs \
+  && adduser -S nodeuser -u 1001 \
+  && chown -R nodeuser:nodejs /app
 USER nodeuser
 
 EXPOSE 8080
-CMD ["npm", "start"]
+
+# Liveness check against the built-in endpoint (honours $PORT, defaults to 8080).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD wget -qO- "http://127.0.0.1:${PORT:-8080}/healthcheck" || exit 1
+
+# Run node directly under tini (not via npm) so the process is a direct child of
+# PID 1 and receives signals for graceful shutdown.
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "build/src/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,6 @@ services:
     restart: always
     ports:
       - '8080:8080'
-    command: ${APP_COMMAND}
     volumes:
       - /app/node_modules
     networks:


### PR DESCRIPTION
## What & why

Part of the production-readiness epic (#163). Closes #171.

The runtime container ran `npm start` as **PID 1**, which forwards signals poorly — so SIGTERM didn't cleanly reach node and the new graceful shutdown (#170) couldn't run. It also had **no container healthcheck** and used a **floating** `node:20-alpine` tag.

## Changes

- **`tini` as PID 1**: run `node build/src/index.js` directly under tini, so node receives SIGTERM (graceful shutdown) and zombies are reaped.
- **`HEALTHCHECK`**: hits the built-in `/healthcheck` endpoint (honours `$PORT`, defaults to 8080).
- **Pinned base image by digest** on both stages (`node:20-alpine@sha256:fb4cd12c…`) for reproducible, tamper-evident builds — bump via Dependabot (#175).
- **`.dockerignore`** to keep the build context lean.

## Verification (built and run locally)

- Image builds cleanly.
- Runs as **non-root** (`uid=1001 nodeuser`).
- **tini 0.19.0** is the init/entrypoint; **node v20.20.2** present.
- Default CMD runs `node build/src/index.js` under tini — reaches `buildContext` (errors only on the expected missing `PG_CONN`), confirming the entrypoint chain.

No app code changed; lint and `prettier --debug-check .` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
