### PR TITLE
P1: Structured JSON logging with request correlation ids (#172)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ PG_CONN='postgres://postgres:postgres@localhost:5432/archive' \
 | `PORT`                 | `8080`       | Port the GraphQL server listens on                 |
 | `ENABLE_GRAPHIQL`      | `false`      | Serve the GraphiQL playground at `/`               |
 | `ENABLE_INTROSPECTION` | `false`      | Allow GraphQL schema introspection                 |
-| `ENABLE_LOGGING`       | `false`      | Enable OpenTelemetry request tracing               |
+| `ENABLE_LOGGING`       | `false`      | Emit OpenTelemetry traces                          |
 | `ENABLE_METRICS`       | `false`      | Expose Prometheus metrics at `/metrics`            |
 | `ENABLED_QUERIES`      | _(all)_      | Comma-separated subset of root query fields        |
 | `ENABLE_JAEGER`        | `false`      | Emit traces to a Jaeger collector                  |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -183,7 +183,7 @@ Boolean variables (`ENABLE_*`) accept `true`/`false`, `1`/`0`, `yes`/`no`, or `o
 | `PG_STATEMENT_TIMEOUT` | `15000` | Server-side timeout in ms per SQL statement, deliberately below the 20s timeout used by known clients so Postgres reclaims work before clients give up. `0` disables |
 | `PORT` | `8080` | Port the GraphQL server listens on |
 | `SHUTDOWN_TIMEOUT_MS` | `20000` | Max ms to drain in-flight requests on SIGTERM before forcing exit. Keep Kubernetes `terminationGracePeriodSeconds` above this value |
-| `LOG_LEVEL` | `info` | `debug` \| `info` \| `warn` \| `error` |
+| `LOG_LEVEL` | `info` | Log verbosity: `trace` \| `debug` \| `info` \| `warn` \| `error` \| `fatal` \| `silent` |
 | `CORS_ORIGIN` | *(disabled)* | Cross-origin access. Unset = same-origin only; `*` = any origin; or a comma-separated allowlist |
 | `READINESS_PING_TIMEOUT_MS` | `2000` | Upper bound on the `/readiness` database ping. Exceeding it returns 503 rather than leaving the probe to hang. Keep it below the orchestrator's probe `timeoutSeconds` |
 | `RATE_LIMIT_MAX` | `600` | Max requests per client IP per window; `0` disables rate limiting |
@@ -195,7 +195,7 @@ Boolean variables (`ENABLE_*`) accept `true`/`false`, `1`/`0`, `yes`/`no`, or `o
 | `GRAPHQL_MAX_COST` | `5000` | Max estimated query cost (depth/field heuristic) |
 | `ENABLE_GRAPHIQL` | `false` | If `true`, serves the GraphiQL playground at `/` |
 | `ENABLE_INTROSPECTION` | `false` | If `true`, allows GraphQL schema introspection |
-| `ENABLE_LOGGING` | `false` | Enable OpenTelemetry request tracing |
+| `ENABLE_LOGGING` | `false` | Emit OpenTelemetry traces (request access logs are always on — see below) |
 | `ENABLE_METRICS` | `false` | If `true`, exposes unauthenticated Prometheus metrics at `/metrics` |
 | `BLOCK_RANGE_SIZE` | `10000` | Max block range a single query may span |
 | `ENABLE_BLOCK_TRANSACTION_DETAILS` | `false` | Include `userCommands` / `zkappCommands` / `feeTransfers` |
@@ -223,6 +223,12 @@ Boolean variables (`ENABLE_*`) accept `true`/`false`, `1`/`0`, `yes`/`no`, or `o
 - To allow browser apps on other origins, set an explicit allowlist: `CORS_ORIGIN=https://app.example.com,https://www.example.com`.
 - Allowlist entries must be exact `scheme://host[:port]` origins: no trailing slash, no wildcard subdomains, and no path.
 - `CORS_ORIGIN=*` opens the API to any origin — convenient for a fully public read API, but make it a deliberate choice rather than a default.
+
+### Notes on logging
+
+- Logs are emitted as **structured JSON** (one object per line) to stdout, ready for aggregation — independent of the optional Jaeger tracing (`ENABLE_LOGGING`).
+- Each request is assigned a correlation id (honouring an inbound `X-Request-Id` header) and logged once with method, path, status, and duration. GraphQL execution errors are logged with the same `requestId`.
+- Probe endpoints (`/healthcheck`, `/readiness`) are not access-logged, to avoid noise from orchestrator health checks.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,7 +47,7 @@ npx @o1-labs/mina-archive-node-graphql
 export PG_CONN='postgresql://postgres:postgres@localhost:5432/archive'
 export ENABLE_GRAPHIQL=true        # optional, exposes GraphiQL UI at /
 mina-archive-node-graphql
-# → Server is running on port: 8080
+# → {"level":"info",...,"port":"8080","msg":"server started"}
 ```
 
 Or via a `.env` file (Node 20+ supports `--env-file` natively):
@@ -89,7 +89,7 @@ docker run --rm \
   -e PG_CONN='postgresql://postgres:postgres@host.docker.internal:5432/archive' \
   -e ENABLE_GRAPHIQL=true \
   ghcr.io/o1-labs/archive-node-api:latest
-# → Server is running on port: 8080
+# → {"level":"info",...,"port":"8080","msg":"server started"}
 ```
 
 Notes:
@@ -147,7 +147,7 @@ Compose will:
 - start Jaeger for tracing
 - build and start the API on port `8080`
 
-Once you see `Server is running on port: 8080` in the logs, you're up.
+Once you see a `server started` log line with `"port":"8080"`, you're up.
 
 ### Variant: only Postgres + Jaeger (use when iterating on the API itself)
 
@@ -228,13 +228,14 @@ Boolean variables (`ENABLE_*`) accept `true`/`false`, `1`/`0`, `yes`/`no`, or `o
 
 - Logs are emitted as **structured JSON** (one object per line) to stdout, ready for aggregation — independent of the optional Jaeger tracing (`ENABLE_LOGGING`).
 - Each request is assigned a correlation id (honouring an inbound `X-Request-Id` header) and logged once with method, path, status, and duration. GraphQL execution errors are logged with the same `requestId`.
+- Inbound `X-Request-Id` values are capped and sanitized before logging; blank or fully unsafe values are replaced with a generated UUID.
 - Probe endpoints (`/healthcheck`, `/readiness`) are not access-logged, to avoid noise from orchestrator health checks.
 
 ---
 
 ## Verification
 
-Once the server prints `Server is running on port: 8080`:
+Once the server prints a `server started` log line:
 
 ```sh
 # liveness probe — process is up (does not check the DB)

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "dotenv": "^16.3.1",
         "graphql": "^16.8.0",
         "graphql-yoga": "5.21.2",
+        "pino": "^10.3.1",
         "postgres": "^3.3.5",
         "prom-client": "^15.1.3"
       },
@@ -8143,6 +8144,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -11575,6 +11582,15 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/auto-bind": {
       "version": "4.0.0",
@@ -18159,6 +18175,15 @@
         "node": ">=18.14.0"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -18723,6 +18748,43 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
@@ -18982,6 +19044,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.1.0.tgz",
+      "integrity": "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/prom-client": {
       "version": "15.1.3",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
@@ -19099,6 +19177,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -19362,6 +19446,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/reflect-metadata": {
@@ -19680,6 +19773,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -20019,6 +20121,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -20095,6 +20206,15 @@
       "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/sponge-case": {
       "version": "1.0.1",
@@ -20840,6 +20960,24 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/thrift": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "dotenv": "^16.3.1",
     "graphql": "^16.8.0",
     "graphql-yoga": "5.21.2",
+    "pino": "^10.3.1",
     "postgres": "^3.3.5",
     "prom-client": "^15.1.3"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { buildServer } from './server/server.js';
 import { buildPlugins } from './server/plugins.js';
 import { createGracefulShutdown } from './server/graceful-shutdown.js';
 import { assertValidConfig } from './config.js';
+import { logger } from './server/logger.js';
 
 const PORT = process.env.PORT || 8080;
 const SHUTDOWN_TIMEOUT_MS = Number(process.env.SHUTDOWN_TIMEOUT_MS) || 20000;
@@ -38,7 +39,7 @@ function withTimeout(
     const server = buildServer(context, plugins);
 
     server.listen(PORT, () => {
-      console.info(`Server is running on port: ${PORT}`);
+      logger.info({ port: PORT }, 'server started');
     });
 
     const shutdown = createGracefulShutdown({
@@ -73,15 +74,15 @@ function withTimeout(
     // Crashes exit non-zero: an exit 0 reads as a clean stop to Kubernetes and
     // systemd, suppressing restarts and non-zero-exit alerting.
     process.on('uncaughtException', (error) => {
-      console.error('Uncaught exception:', error);
+      logger.error({ err: error }, 'uncaught exception');
       void shutdown('uncaughtException', 1);
     });
     process.on('unhandledRejection', (reason) => {
-      console.error('Unhandled rejection:', reason);
+      logger.error({ err: reason }, 'unhandled rejection');
       void shutdown('unhandledRejection', 1);
     });
   } catch (error) {
-    console.error('An error occurred:', error);
+    logger.error({ err: error }, 'fatal error during startup');
     process.exit(1); // exit with an error code
   }
 })();

--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -1,0 +1,67 @@
+import pino from 'pino';
+import type { LogLevel } from 'graphql-yoga';
+
+export { createLogger, logger, resolveLogLevel, resolveYogaLogLevel };
+export type { Logger };
+
+type Logger = pino.Logger;
+type PinoLogLevel =
+  | 'trace'
+  | 'debug'
+  | 'info'
+  | 'warn'
+  | 'error'
+  | 'fatal'
+  | 'silent';
+
+const VALID_LEVELS = new Set<PinoLogLevel>([
+  'trace',
+  'debug',
+  'info',
+  'warn',
+  'error',
+  'fatal',
+  'silent',
+]);
+
+function resolveLogLevel(
+  env: Record<string, string | undefined> = process.env
+): PinoLogLevel {
+  const requested = (env.LOG_LEVEL ?? 'info').toLowerCase();
+  return VALID_LEVELS.has(requested as PinoLogLevel)
+    ? (requested as PinoLogLevel)
+    : 'info';
+}
+
+function resolveYogaLogLevel(
+  env: Record<string, string | undefined> = process.env
+): LogLevel | false {
+  const level = resolveLogLevel(env);
+  if (level === 'trace') return 'debug';
+  if (level === 'fatal') return 'error';
+  if (level === 'silent') return false;
+  return level;
+}
+
+/**
+ * Build the application logger. Emits structured JSON (one object per line) with
+ * ISO timestamps, suitable for log aggregation, and is independent of the
+ * optional Jaeger tracing. The level comes from `LOG_LEVEL`; an unrecognised
+ * value falls back to `info` rather than throwing at startup.
+ */
+function createLogger(
+  env: Record<string, string | undefined> = process.env
+): Logger {
+  const level = resolveLogLevel(env);
+  return pino({
+    level,
+    base: { service: env.JAEGER_SERVICE_NAME ?? 'archive-api' },
+    timestamp: pino.stdTimeFunctions.isoTime,
+    formatters: {
+      // Log the level name ("info") instead of its numeric code.
+      level: (label) => ({ level: label }),
+    },
+  });
+}
+
+const logger = createLogger();

--- a/src/server/logger.ts
+++ b/src/server/logger.ts
@@ -1,3 +1,4 @@
+import { hostname } from 'node:os';
 import pino from 'pino';
 import type { LogLevel } from 'graphql-yoga';
 
@@ -55,7 +56,11 @@ function createLogger(
   const level = resolveLogLevel(env);
   return pino({
     level,
-    base: { service: env.JAEGER_SERVICE_NAME ?? 'archive-api' },
+    base: {
+      pid: process.pid,
+      hostname: hostname(),
+      service: env.JAEGER_SERVICE_NAME ?? 'archive-api',
+    },
     timestamp: pino.stdTimeFunctions.isoTime,
     formatters: {
       // Log the level name ("info") instead of its numeric code.

--- a/src/server/plugins.ts
+++ b/src/server/plugins.ts
@@ -2,6 +2,7 @@ import { useLogger } from '@envelop/core';
 import { useGraphQlJit } from '@envelop/graphql-jit';
 import { useDisableIntrospection } from '@envelop/disable-introspection';
 import { useOpenTelemetry } from '@envelop/opentelemetry';
+import type { GraphQLError } from 'graphql';
 
 import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { initJaegerProvider } from '../tracing/jaeger-tracing.js';
@@ -70,7 +71,14 @@ async function buildPlugins() {
             {
               requestId: request ? requestIdFor(request) : undefined,
               variables: args?.args?.variableValues,
-              errors: args.result.errors,
+              errors: args.result.errors.map((error: GraphQLError) => ({
+                message: error.message,
+                path: error.path,
+                locations: error.locations,
+                stack: error.originalError?.stack ?? error.stack,
+                code: (error.originalError as { code?: string } | undefined)
+                  ?.code,
+              })),
             },
             'graphql execution errors'
           );

--- a/src/server/plugins.ts
+++ b/src/server/plugins.ts
@@ -2,7 +2,6 @@ import { useLogger } from '@envelop/core';
 import { useGraphQlJit } from '@envelop/graphql-jit';
 import { useDisableIntrospection } from '@envelop/disable-introspection';
 import { useOpenTelemetry } from '@envelop/opentelemetry';
-import { inspect } from 'node:util';
 
 import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { initJaegerProvider } from '../tracing/jaeger-tracing.js';
@@ -10,12 +9,17 @@ import { parseBoolean } from '../config.js';
 import { useMetrics } from './metrics.js';
 import { useRateLimit } from './rate-limit.js';
 import { buildArmorPlugins } from './graphql-armor.js';
+import { logger } from './logger.js';
+import { useRequestLogging, requestIdFor } from './request-logging.js';
 
 export { buildPlugins };
 
 async function buildPlugins() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const plugins: any[] = [];
+
+  // Structured per-request access logging with correlation ids.
+  plugins.push(useRequestLogging());
 
   // Per-IP request rate limiting. Runs on every request before GraphQL parsing,
   // so over-limit traffic is rejected as cheaply as possible.
@@ -57,20 +61,18 @@ async function buildPlugins() {
 
   plugins.push(
     useLogger({
-      logFn: (eventName, args) => {
+      logFn: (_eventName, args) => {
         if (args?.result?.errors) {
-          console.debug(
-            eventName,
-            inspect(args.args.contextValue.params, {
-              showHidden: false,
-              depth: null,
-              colors: true,
-            }),
-            inspect(args.result.errors, {
-              showHidden: false,
-              depth: null,
-              colors: true,
-            })
+          const request = args?.args?.contextValue?.request as
+            | Request
+            | undefined;
+          logger.error(
+            {
+              requestId: request ? requestIdFor(request) : undefined,
+              variables: args?.args?.variableValues,
+              errors: args.result.errors,
+            },
+            'graphql execution errors'
           );
         }
       },

--- a/src/server/request-logging.ts
+++ b/src/server/request-logging.ts
@@ -7,8 +7,10 @@ export { useRequestLogging, requestIdFor };
 
 /** Paths whose requests are not access-logged (frequent orchestrator probes). */
 const QUIET_PATHS = new Set(['/healthcheck', '/readiness']);
+/** Max characters kept from an inbound X-Request-Id. */
 const MAX_REQUEST_ID_LENGTH = 128;
-const REQUEST_ID_PATTERN = /^[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=-]+$/;
+/** Printable ASCII only, minus quote and backslash. */
+const UNSAFE_REQUEST_ID_CHARS = /[^\x20-\x7e]|["\\]/g;
 
 /**
  * Correlation id per in-flight request. Stored in a WeakMap so it is dropped
@@ -21,24 +23,21 @@ function requestIdFor(request: Request): string | undefined {
   return requestIds.get(request);
 }
 
+function sanitizeRequestId(raw: string | null): string {
+  if (!raw) return randomUUID();
+  const cleaned = raw
+    .replace(UNSAFE_REQUEST_ID_CHARS, '')
+    .slice(0, MAX_REQUEST_ID_LENGTH)
+    .trim();
+  return cleaned.length > 0 ? cleaned : randomUUID();
+}
+
 function pathOf(rawUrl: string): string {
   try {
     return new URL(rawUrl).pathname;
   } catch {
     return rawUrl;
   }
-}
-
-function requestIdFromHeader(header: string | null): string {
-  const candidate = header?.trim();
-  if (
-    candidate &&
-    candidate.length <= MAX_REQUEST_ID_LENGTH &&
-    REQUEST_ID_PATTERN.test(candidate)
-  ) {
-    return candidate;
-  }
-  return randomUUID();
 }
 
 /**
@@ -51,7 +50,7 @@ function useRequestLogging(log: Logger = defaultLogger): Plugin {
   const startTimes = new WeakMap<Request, number>();
   return {
     onRequest({ request }) {
-      const id = requestIdFromHeader(request.headers.get('x-request-id'));
+      const id = sanitizeRequestId(request.headers.get('x-request-id'));
       requestIds.set(request, id);
       startTimes.set(request, Date.now());
     },
@@ -59,14 +58,23 @@ function useRequestLogging(log: Logger = defaultLogger): Plugin {
       const path = pathOf(request.url);
       if (QUIET_PATHS.has(path)) return;
 
-      const start = startTimes.get(request);
+      let id = requestIds.get(request);
+      let start = startTimes.get(request);
+      if (id === undefined || start === undefined) {
+        // CORS and health-check plugins can short-circuit before onRequest, but
+        // onResponse still runs. Backfill so access lines remain correlated.
+        id = sanitizeRequestId(request.headers.get('x-request-id'));
+        start = Date.now();
+        requestIds.set(request, id);
+        startTimes.set(request, start);
+      }
       log.info(
         {
-          requestId: requestIds.get(request),
+          requestId: id,
           method: request.method,
           path,
           status: response.status,
-          durationMs: start !== undefined ? Date.now() - start : undefined,
+          durationMs: Date.now() - start,
         },
         'request completed'
       );

--- a/src/server/request-logging.ts
+++ b/src/server/request-logging.ts
@@ -1,0 +1,75 @@
+import { randomUUID } from 'node:crypto';
+import type { Plugin } from 'graphql-yoga';
+import { logger as defaultLogger } from './logger.js';
+import type { Logger } from './logger.js';
+
+export { useRequestLogging, requestIdFor };
+
+/** Paths whose requests are not access-logged (frequent orchestrator probes). */
+const QUIET_PATHS = new Set(['/healthcheck', '/readiness']);
+const MAX_REQUEST_ID_LENGTH = 128;
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=-]+$/;
+
+/**
+ * Correlation id per in-flight request. Stored in a WeakMap so it is dropped
+ * automatically once the request is garbage-collected. Other log sites (e.g. the
+ * GraphQL error logger) can look it up to tie their lines to the access log.
+ */
+const requestIds = new WeakMap<Request, string>();
+
+function requestIdFor(request: Request): string | undefined {
+  return requestIds.get(request);
+}
+
+function pathOf(rawUrl: string): string {
+  try {
+    return new URL(rawUrl).pathname;
+  } catch {
+    return rawUrl;
+  }
+}
+
+function requestIdFromHeader(header: string | null): string {
+  const candidate = header?.trim();
+  if (
+    candidate &&
+    candidate.length <= MAX_REQUEST_ID_LENGTH &&
+    REQUEST_ID_PATTERN.test(candidate)
+  ) {
+    return candidate;
+  }
+  return randomUUID();
+}
+
+/**
+ * Yoga plugin that assigns each request a correlation id (honouring an inbound
+ * bounded `X-Request-Id`) and emits one structured access-log line per request
+ * with the id, method, path, status, and duration. Probe endpoints are skipped
+ * to avoid log spam. `log` is injectable for tests.
+ */
+function useRequestLogging(log: Logger = defaultLogger): Plugin {
+  const startTimes = new WeakMap<Request, number>();
+  return {
+    onRequest({ request }) {
+      const id = requestIdFromHeader(request.headers.get('x-request-id'));
+      requestIds.set(request, id);
+      startTimes.set(request, Date.now());
+    },
+    onResponse({ request, response }) {
+      const path = pathOf(request.url);
+      if (QUIET_PATHS.has(path)) return;
+
+      const start = startTimes.get(request);
+      log.info(
+        {
+          requestId: requestIds.get(request),
+          method: request.method,
+          path,
+          status: response.status,
+          durationMs: start !== undefined ? Date.now() - start : undefined,
+        },
+        'request completed'
+      );
+    },
+  };
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,3 +1,4 @@
+import { inspect } from 'node:util';
 import { createYoga } from 'graphql-yoga';
 import { createServer } from 'http';
 import { Plugin } from '@envelop/core';
@@ -6,7 +7,7 @@ import type { GraphQLContext } from '../context.js';
 import { parseBoolean } from '../config.js';
 import { useReadiness } from './readiness.js';
 import { resolveCorsOptions, warnIfCorsDisabled } from './cors.js';
-import { resolveYogaLogLevel } from './logger.js';
+import { logger, resolveYogaLogLevel } from './logger.js';
 
 export {
   BLOCK_RANGE_SIZE,
@@ -15,18 +16,39 @@ export {
   buildServer,
 };
 
-const LOG_LEVEL = resolveYogaLogLevel();
 const BLOCK_RANGE_SIZE = Number(process.env.BLOCK_RANGE_SIZE) || 10000;
 const ENABLE_BLOCK_TRANSACTION_DETAILS = parseBoolean(
   process.env.ENABLE_BLOCK_TRANSACTION_DETAILS
 );
+const YOGA_LOG_LEVEL = resolveYogaLogLevel();
+
+const yogaLog =
+  (level: 'debug' | 'info' | 'warn' | 'error') =>
+  (...args: unknown[]) => {
+    const err = args.find((arg): arg is Error => arg instanceof Error);
+    const msg = args
+      .filter((arg) => !(arg instanceof Error))
+      .map((arg) =>
+        typeof arg === 'string' ? arg : inspect(arg, { depth: 3 })
+      )
+      .join(' ');
+    logger[level](err ? { err } : {}, msg || 'yoga');
+  };
 
 function buildYoga(context: GraphQLContext, plugins: Plugin[]) {
   const cors = resolveCorsOptions();
 
   return createYoga<GraphQLContext>({
     schema,
-    logging: LOG_LEVEL,
+    logging:
+      YOGA_LOG_LEVEL === false
+        ? false
+        : {
+            debug: yogaLog('debug'),
+            info: yogaLog('info'),
+            warn: yogaLog('warn'),
+            error: yogaLog('error'),
+          },
     graphqlEndpoint: '/',
     landingPage: false,
     // Liveness — the process is up and serving HTTP.

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,4 +1,4 @@
-import { createYoga, LogLevel } from 'graphql-yoga';
+import { createYoga } from 'graphql-yoga';
 import { createServer } from 'http';
 import { Plugin } from '@envelop/core';
 import { schema } from '../resolvers.js';
@@ -6,6 +6,7 @@ import type { GraphQLContext } from '../context.js';
 import { parseBoolean } from '../config.js';
 import { useReadiness } from './readiness.js';
 import { resolveCorsOptions, warnIfCorsDisabled } from './cors.js';
+import { resolveYogaLogLevel } from './logger.js';
 
 export {
   BLOCK_RANGE_SIZE,
@@ -14,7 +15,7 @@ export {
   buildServer,
 };
 
-const LOG_LEVEL = (process.env.LOG_LEVEL as LogLevel) || 'info';
+const LOG_LEVEL = resolveYogaLogLevel();
 const BLOCK_RANGE_SIZE = Number(process.env.BLOCK_RANGE_SIZE) || 10000;
 const ENABLE_BLOCK_TRANSACTION_DETAILS = parseBoolean(
   process.env.ENABLE_BLOCK_TRANSACTION_DETAILS

--- a/tests/unit/logging.test.ts
+++ b/tests/unit/logging.test.ts
@@ -1,0 +1,106 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { createYoga } from 'graphql-yoga';
+import {
+  createLogger,
+  resolveYogaLogLevel,
+} from '../../src/server/logger.js';
+import type { Logger } from '../../src/server/logger.js';
+import { useRequestLogging } from '../../src/server/request-logging.js';
+import { schema } from '../../src/resolvers.js';
+
+type Entry = { obj: Record<string, unknown>; msg: string };
+
+function captureLogger(entries: Entry[]): Logger {
+  return {
+    info: (obj: Record<string, unknown>, msg: string) =>
+      entries.push({ obj, msg }),
+  } as unknown as Logger;
+}
+
+function serverWith(entries: Entry[]) {
+  return createYoga({
+    schema,
+    graphqlEndpoint: '/',
+    plugins: [useRequestLogging(captureLogger(entries))],
+  });
+}
+
+describe('createLogger', () => {
+  test('honours a valid LOG_LEVEL', () => {
+    assert.strictEqual(createLogger({ LOG_LEVEL: 'debug' }).level, 'debug');
+  });
+
+  test('falls back to info for an unrecognised level', () => {
+    assert.strictEqual(createLogger({ LOG_LEVEL: 'bogus' }).level, 'info');
+  });
+
+  test('maps LOG_LEVEL values to Yoga-supported levels', () => {
+    assert.strictEqual(resolveYogaLogLevel({ LOG_LEVEL: 'trace' }), 'debug');
+    assert.strictEqual(resolveYogaLogLevel({ LOG_LEVEL: 'fatal' }), 'error');
+    assert.strictEqual(resolveYogaLogLevel({ LOG_LEVEL: 'silent' }), false);
+  });
+});
+
+describe('useRequestLogging', () => {
+  test('emits one structured access line per request', async () => {
+    const entries: Entry[] = [];
+    const yoga = serverWith(entries);
+    await yoga.fetch('http://localhost/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query: '{ __typename }' }),
+    });
+
+    assert.strictEqual(entries.length, 1);
+    const { obj, msg } = entries[0];
+    assert.strictEqual(msg, 'request completed');
+    assert.strictEqual(obj.method, 'POST');
+    assert.strictEqual(obj.path, '/');
+    assert.strictEqual(obj.status, 200);
+    assert.strictEqual(typeof obj.requestId, 'string');
+    assert.strictEqual(typeof obj.durationMs, 'number');
+  });
+
+  test('honours an inbound X-Request-Id for correlation', async () => {
+    const entries: Entry[] = [];
+    const yoga = serverWith(entries);
+    await yoga.fetch('http://localhost/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': 'trace-123',
+      },
+      body: JSON.stringify({ query: '{ __typename }' }),
+    });
+
+    assert.strictEqual(entries[0].obj.requestId, 'trace-123');
+  });
+
+  test('rejects oversized inbound X-Request-Id values', async () => {
+    const entries: Entry[] = [];
+    const yoga = serverWith(entries);
+    const oversized = 'x'.repeat(129);
+
+    await yoga.fetch('http://localhost/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-request-id': oversized,
+      },
+      body: JSON.stringify({ query: '{ __typename }' }),
+    });
+
+    const requestId = entries[0].obj.requestId;
+    assert.strictEqual(typeof requestId, 'string');
+    assert.notStrictEqual(requestId, oversized);
+    assert.ok((requestId as string).length <= 128);
+  });
+
+  test('does not access-log probe endpoints', async () => {
+    const entries: Entry[] = [];
+    const yoga = serverWith(entries);
+    await yoga.fetch('http://localhost/healthcheck');
+    assert.strictEqual(entries.length, 0);
+  });
+});

--- a/tests/unit/logging.test.ts
+++ b/tests/unit/logging.test.ts
@@ -77,24 +77,60 @@ describe('useRequestLogging', () => {
     assert.strictEqual(entries[0].obj.requestId, 'trace-123');
   });
 
-  test('rejects oversized inbound X-Request-Id values', async () => {
+  test('caps and sanitises an inbound X-Request-Id', async () => {
     const entries: Entry[] = [];
     const yoga = serverWith(entries);
-    const oversized = 'x'.repeat(129);
-
     await yoga.fetch('http://localhost/', {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'x-request-id': oversized,
+        'x-request-id': `bad"\\\u0007id${'A'.repeat(500)}`,
       },
       body: JSON.stringify({ query: '{ __typename }' }),
     });
 
-    const requestId = entries[0].obj.requestId;
-    assert.strictEqual(typeof requestId, 'string');
-    assert.notStrictEqual(requestId, oversized);
-    assert.ok((requestId as string).length <= 128);
+    const id = entries[0].obj.requestId as string;
+    assert.strictEqual(id.length, 128);
+    assert.match(id, /^[\x20-\x7e]+$/);
+    assert.ok(!id.includes('"'));
+    assert.ok(!id.includes('\\'));
+  });
+
+  test('generates an id when the inbound X-Request-Id is blank', async () => {
+    const entries: Entry[] = [];
+    const yoga = serverWith(entries);
+    await yoga.fetch('http://localhost/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-request-id': '   ' },
+      body: JSON.stringify({ query: '{ __typename }' }),
+    });
+
+    assert.match(entries[0].obj.requestId as string, /^[0-9a-f-]{36}$/);
+  });
+
+  test('backfills request metadata for CORS preflight responses', async () => {
+    const entries: Entry[] = [];
+    const origin = 'https://explorer.example.com';
+    const yoga = createYoga({
+      schema,
+      graphqlEndpoint: '/',
+      cors: { origin, methods: ['GET', 'POST'] },
+      plugins: [useRequestLogging(captureLogger(entries))],
+    });
+    await yoga.fetch('http://localhost/', {
+      method: 'OPTIONS',
+      headers: {
+        origin,
+        'access-control-request-method': 'POST',
+        'access-control-request-headers': 'content-type',
+      },
+    });
+
+    assert.strictEqual(entries.length, 1);
+    assert.strictEqual(entries[0].obj.method, 'OPTIONS');
+    assert.strictEqual(entries[0].obj.status, 204);
+    assert.strictEqual(typeof entries[0].obj.requestId, 'string');
+    assert.strictEqual(typeof entries[0].obj.durationMs, 'number');
   });
 
   test('does not access-log probe endpoints', async () => {


### PR DESCRIPTION
## What & why

Part of the production-readiness epic (#163). Closes #172.

Logging used `console.info/error` and an `inspect(..., {colors:true})` error dump — TTY-oriented, not aggregation-friendly — with **no request ids**, and was entangled with the Jaeger toggle.

## Changes

- **`logger.ts`** — a pino structured logger: JSON lines, ISO timestamps, level from `LOG_LEVEL` (invalid values fall back to `info` instead of throwing at startup), independent of tracing.
- **`useRequestLogging`** plugin — assigns each request a correlation id (honouring an inbound `X-Request-Id`) and emits one structured access line per request with `method`, `path`, `status`, `durationMs`. Probe endpoints (`/healthcheck`, `/readiness`) are skipped to avoid orchestrator noise.
- **GraphQL execution errors** now log as structured JSON tagged with the same `requestId`.
- `console.*` in the entry point replaced with the logger.

New dependency: `pino`.

## Testing

- `npm run build` — clean
- `npm run test:unit` — all pass; new tests cover level parsing/fallback and prove (through Yoga) the access-line shape, `X-Request-Id` correlation, and probe-path suppression
- `npm run lint` / `npx prettier --debug-check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
