### PR TITLE
P1: Supply-chain security — Dependabot, npm audit gate, SBOM (#175)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     groups:
       production-dependencies:
         dependency-type: production
@@ -18,9 +18,15 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - '*'
 
   # Keep the pinned base-image digest in the Dockerfile fresh.
   - package-ecosystem: docker
     directory: '/'
     schedule:
       interval: weekly
+    open-pull-requests-limit: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Application dependencies. Production and development updates are grouped
+  # separately so security-relevant runtime bumps are easy to review on their own.
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
+
+  # Keep CI action versions current and patched.
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+
+  # Keep the pinned base-image digest in the Dockerfile fresh.
+  - package-ecosystem: docker
+    directory: '/'
+    schedule:
+      interval: weekly

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,49 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly, so advisories on unchanged code are still surfaced.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  npm-audit:
+    name: npm audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      # Hard gate: fail on critical advisories in what actually ships (prod deps).
+      - name: Audit production dependencies (gate on critical)
+        run: npm audit --omit=dev --audit-level=critical
+      # Informational: surface the full picture (incl. dev tooling) without blocking.
+      - name: Full audit (informational)
+        run: npm audit || true
+
+  sbom:
+    name: SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate CycloneDX SBOM
+        continue-on-error: true
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.cyclonedx.json
+      - name: Upload SBOM artifact
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.cyclonedx.json

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   npm-audit:
     name: npm audit
@@ -21,7 +25,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       # Hard gate: fail on critical advisories in what actually ships (prod deps).
       - name: Audit production dependencies (gate on critical)
         run: npm audit --omit=dev --audit-level=critical
@@ -35,15 +39,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Generate CycloneDX SBOM
-        continue-on-error: true
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: .
           format: cyclonedx-json
           output-file: sbom.cyclonedx.json
       - name: Upload SBOM artifact
-        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: sbom
           path: sbom.cyclonedx.json
+          if-no-files-found: error


### PR DESCRIPTION
## What & why

Part of the production-readiness epic (#163). Refs #175.

There were no supply-chain controls: no Dependabot, no audit gate, no SBOM.

## Changes

- **`.github/dependabot.yml`** — weekly updates for npm (production/development grouped), GitHub Actions, and Docker (keeps the pinned base-image digest from #171 fresh).
- **`.github/workflows/security.yaml`**:
  - **npm audit** — hard gate on **critical** advisories in production deps (what actually ships in the image/npm package), plus a full informational audit for visibility.
  - **CycloneDX SBOM** generation, uploaded as a build artifact.

## Notes

- **Gate is "prod-critical", not "all-high":** a blocking audit over *all* deps would fail immediately — the repo has 115 advisories, almost all from **dev tooling** (artillery, codegen). Production deps have **0 critical / 4 high**, and the highs are OpenTelemetry + `fast-uri` transitives that Dependabot and the Yoga 5 upgrade (#176) will clear. The gate blocks prod **criticals** today, surfaces everything else, and can be tightened to `high` once #176 lands.
- **Trivy/Grype image scanning deferred:** I dropped the Trivy job rather than ship it red (the scanner action failed to run in CI and I couldn't verify it blind). Dependabot's npm + docker ecosystems already surface vulnerable deps and base images; a verified image-scan job can be added as a follow-up. Hence **Refs** #175, not Closes.

## Testing

- `npm audit --omit=dev --audit-level=critical` → exit 0 (the blocking gate passes)
- `prettier --debug-check .` — clean; YAML validated
- No application code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
