### PR TITLE
fix(scripts): detect docker compose v2 in download_db.sh

### DIFF
--- a/scripts/download_db.sh
+++ b/scripts/download_db.sh
@@ -16,8 +16,21 @@ DB_DIR="db"
 PG_DUMP="archive.sql"
 BASE_URL="https://storage.googleapis.com/mina-archive-dumps"
 
-# Stop docker containers 
-docker-compose stop postgres
+# Pick whichever Compose is installed. The docs tell users to run
+# `docker compose up` (Compose v2), but this script hardcoded the v1
+# `docker-compose` binary, which is EOL since 2023 and absent on v2-only hosts —
+# so the documented setup failed here with "command not found".
+if command -v docker &> /dev/null && docker compose version &> /dev/null; then
+  DOCKER_COMPOSE=(docker compose)
+elif command -v docker-compose &> /dev/null; then
+  DOCKER_COMPOSE=(docker-compose)
+else
+  echo "Error: neither 'docker compose' (v2) nor 'docker-compose' (v1) found" >&2
+  exit 1
+fi
+
+# Stop docker containers
+"${DOCKER_COMPOSE[@]}" stop postgres
 
 # clear db and data directories
 rm -rf "$DB_DIR"


### PR DESCRIPTION
## What & why

`scripts/download_db.sh` hardcodes `docker-compose stop postgres` — the Compose **v1** binary, EOL since 2023 and absent on v2-only hosts. But `docs/getting-started.md` (Path C) tells users to run `docker compose up` (**v2**). So on a v2-only machine the documented setup works right up until `download_db.sh`, which then fails with `docker-compose: command not found`.

This detects whichever Compose is installed — preferring v2 — and errors clearly if neither is present.

## Provenance

This is the one salvageable hunk from #125 (Staketab). Per the review there, its other two files (`.env.example.compose`, `scripts/generate_libp2p.sh`) now conflict with #158's mainnet-3.3.1 refresh and are best dropped, so this lands the real improvement on a clean branch off `main`. Closes #125's useful part; recommend closing that PR once this merges.

## Testing

- `shellcheck scripts/download_db.sh` — clean
- `bash -n` — clean
- Simulated a v2-only host (docker present, `docker-compose` absent): detection resolves to `docker compose` and reaches `stop postgres`. Simulated a v1-only host: resolves to `docker-compose`. Missing-both: exits 1 with a clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACRnT8ZHiAqEhusugky6fu