### PR TITLE
chore: release 0.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@o1-labs/mina-archive-node-graphql",
-  "version": "0.0.5",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@o1-labs/mina-archive-node-graphql",
-      "version": "0.0.5",
+      "version": "0.0.9",
       "license": "ISC",
       "dependencies": {
         "@envelop/core": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@o1-labs/mina-archive-node-graphql",
-  "version": "0.0.6",
+  "version": "0.0.9",
   "description": "A NodeJS GraphQL server for exposing Mina Protocol archive node data for o1js/zkApps",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Bumps `@o1-labs/mina-archive-node-graphql` from **0.0.6** to **0.0.9** so the next `v*` tag push can publish. Version-only change — no source, schema, or dependency changes.

Also syncs `package-lock.json`, which the 0.0.6 release left behind at `0.0.5`.

## Why 0.0.9 and not 0.0.7

Only **0.0.6** was ever published to npm under the scoped name, but the `v0.0.7` and `v0.0.8` git tags already exist on origin from before the scoped-package reset:

| tag | commit | state |
|---|---|---|
| `v0.0.7` | `de9b093` | not an ancestor of `main` — abandoned |
| `v0.0.8` | `40ec094` | ancestor of `main`, but predates the 0.0.6 reset (#153) |
| `v0.0.6` | `81caf96` | the actual published release point |

Those tag names are unusable without rewriting published history, so 0.0.9 is the next free version.

## Changes since the published `v0.0.6`

- fix(network-service): don't crash when canonical or pending rows are missing (#160)
- Constrain `orderBy` type in blocks service to reduce SQL-injection surface (#131) — internal only, no `schema.graphql` change
- test: automated consensus-vs-chain integration test replacing the dead port-validation dev tools (#159)
- ci: smoke load test against a static archive-DB fixture (#157)
- ci(publish): `mina-local-network` service so `npm test` passes (#154)
- chore: refresh stale Mina references to mainnet 3.3.1 (#158)
- docs: README trim, `AGENTS.md`, scoped npm install + prebuilt Docker path (#155, #156)

No public API break — this stays a patch-level release.

## Verification

- `npm ci` clean against the updated lockfile
- `npm run test:unit` — all pass
- All workflows green on `main` @ `491b8bc` (Run Tests, Unit Tests & Coverage, Smoke Load Test, Lint, CI)

## Release steps after merge

1. Tag the merge commit `v0.0.9` and push it
2. The `Publish Package` workflow runs `npm test` against `mina-local-network`, then `npm publish --provenance --access public`

🤖 Generated with [Claude Code](https://claude.com/claude-code)