### PR TITLE
fix(tests): wait for archive indexing before asserting on emitted blocks

### DIFF
--- a/tests/resolvers.test.ts
+++ b/tests/resolvers.test.ts
@@ -216,6 +216,68 @@ describe('Query Resolvers', async () => {
     })) as NetworkQueryResult;
   }
 
+  /**
+   * The archive node ingests blocks into Postgres asynchronously, so a
+   * transaction the daemon already reports as included is not necessarily
+   * queryable yet. Re-run `runQuery` until the archive reports more blocks for
+   * the address than it did before the emit.
+   *
+   * The predicate is deliberately independent of what the tests assert — it
+   * waits for "a new block is visible", not "the count matches what we expect".
+   * Polling on the expected value would make the assertions tautological and
+   * would turn a genuine wrong-count regression into an opaque timeout instead
+   * of a clean assertion diff.
+   */
+  async function waitForNewBlock<T>(
+    runQuery: () => Promise<T>,
+    countBlocks: (result: T) => number,
+    blocksBefore: number,
+    { attempts = 30, delayMs = 1000 } = {}
+  ): Promise<T> {
+    let result = await runQuery();
+    for (let attempt = 1; attempt < attempts; attempt++) {
+      if (countBlocks(result) > blocksBefore) return result;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      result = await runQuery();
+    }
+    if (countBlocks(result) > blocksBefore) return result;
+    throw new Error(
+      `Archive did not index a new block within ${
+        (attempts * delayMs) / 1000
+      }s (still ${blocksBefore} block(s) for this address). The daemon reported ` +
+        `the transaction as included, so this is either archive lag beyond the ` +
+        `timeout or a transaction that produced no block entry.`
+    );
+  }
+
+  async function emitAndQueryEvents(
+    address: string,
+    emit: () => Promise<void>
+  ): Promise<EventQueryResult> {
+    const blocksBefore = (await executeEventsQuery({ address })).data.events
+      .length;
+    await emit();
+    return waitForNewBlock(
+      () => executeEventsQuery({ address }),
+      (result) => result.data.events.length,
+      blocksBefore
+    );
+  }
+
+  async function emitAndQueryActions(
+    address: string,
+    emit: () => Promise<void>
+  ): Promise<ActionQueryResult> {
+    const blocksBefore = (await executeActionsQuery({ address })).data.actions
+      .length;
+    await emit();
+    return waitForNewBlock(
+      () => executeActionsQuery({ address }),
+      (result) => result.data.actions.length,
+      blocksBefore
+    );
+  }
+
   before(async () => {
     try {
       setNetworkConfig();
@@ -368,10 +430,9 @@ describe('Query Resolvers', async () => {
 
     describe('After emitting an event with a single field once', async () => {
       before(async () => {
-        await emitSingleEvent(zkApp, senderKeypair);
-        results = await executeEventsQuery({
-          address: zkApp.address.toBase58(),
-        });
+        results = await emitAndQueryEvents(zkApp.address.toBase58(), () =>
+          emitSingleEvent(zkApp, senderKeypair)
+        );
         eventsResponse = results.data.events;
         lastBlockEvents = eventsResponse[eventsResponse.length - 1].eventData!;
       });
@@ -388,10 +449,9 @@ describe('Query Resolvers', async () => {
       let results: EventQueryResult;
       const numberOfEmits = 3;
       before(async () => {
-        await emitSingleEvent(zkApp, senderKeypair, { numberOfEmits });
-        results = await executeEventsQuery({
-          address: zkApp.address.toBase58(),
-        });
+        results = await emitAndQueryEvents(zkApp.address.toBase58(), () =>
+          emitSingleEvent(zkApp, senderKeypair, { numberOfEmits })
+        );
         eventsResponse = results.data.events;
         lastBlockEvents = eventsResponse[eventsResponse.length - 1].eventData!;
       });
@@ -410,15 +470,9 @@ describe('Query Resolvers', async () => {
       let results: EventQueryResult;
       const baseStruct = randomStruct();
       before(async () => {
-        await emitMultipleFieldsEvent(
-          zkApp,
-          senderKeypair,
-          undefined,
-          baseStruct
+        results = await emitAndQueryEvents(zkApp.address.toBase58(), () =>
+          emitMultipleFieldsEvent(zkApp, senderKeypair, undefined, baseStruct)
         );
-        results = await executeEventsQuery({
-          address: zkApp.address.toBase58(),
-        });
         eventsResponse = results.data.events;
         lastBlockEvents = eventsResponse[eventsResponse.length - 1].eventData!;
       });
@@ -440,15 +494,14 @@ describe('Query Resolvers', async () => {
       const numberOfEmits = 3;
       const baseStruct = randomStruct();
       before(async () => {
-        await emitMultipleFieldsEvent(
-          zkApp,
-          senderKeypair,
-          { numberOfEmits },
-          baseStruct
+        results = await emitAndQueryEvents(zkApp.address.toBase58(), () =>
+          emitMultipleFieldsEvent(
+            zkApp,
+            senderKeypair,
+            { numberOfEmits },
+            baseStruct
+          )
         );
-        results = await executeEventsQuery({
-          address: zkApp.address.toBase58(),
-        });
         eventsResponse = results.data.events;
         lastBlockEvents = eventsResponse[eventsResponse.length - 1].eventData!;
       });
@@ -472,15 +525,14 @@ describe('Query Resolvers', async () => {
       const numberOfEmits = 3;
       const baseStruct = randomStruct();
       before(async () => {
-        await emitMultipleFieldsEvents(
-          zkApp,
-          senderKeypair,
-          { numberOfEmits },
-          baseStruct
+        results = await emitAndQueryEvents(zkApp.address.toBase58(), () =>
+          emitMultipleFieldsEvents(
+            zkApp,
+            senderKeypair,
+            { numberOfEmits },
+            baseStruct
+          )
         );
-        results = await executeEventsQuery({
-          address: zkApp.address.toBase58(),
-        });
         eventsResponse = results.data.events;
         lastBlockEvents = eventsResponse[eventsResponse.length - 1].eventData!;
       });
@@ -581,10 +633,9 @@ describe('Query Resolvers', async () => {
         structs: [s1, s2, s3],
       };
       before(async () => {
-        await emitAction(zkApp, senderKeypair, undefined, testStructArray);
-        results = await executeActionsQuery({
-          address: zkApp.address.toBase58(),
-        });
+        results = await emitAndQueryActions(zkApp.address.toBase58(), () =>
+          emitAction(zkApp, senderKeypair, undefined, testStructArray)
+        );
         actionsResponse = results.data.actions;
         lastBlockActions =
           actionsResponse[actionsResponse.length - 1].actionData!;
@@ -616,10 +667,9 @@ describe('Query Resolvers', async () => {
         structs: [s1, s2, s3],
       };
       before(async () => {
-        await emitAction(zkApp, senderKeypair, { numberOfEmits }, testStructs);
-        results = await executeActionsQuery({
-          address: zkApp.address.toBase58(),
-        });
+        results = await emitAndQueryActions(zkApp.address.toBase58(), () =>
+          emitAction(zkApp, senderKeypair, { numberOfEmits }, testStructs)
+        );
         actionsResponse = results.data.actions;
         lastBlockActions =
           actionsResponse[actionsResponse.length - 1].actionData!;

--- a/zkapp/utils.ts
+++ b/zkapp/utils.ts
@@ -269,6 +269,9 @@ async function sendTransaction(transaction: Mina.Transaction<any, any>) {
     await pendingTx.wait({ maxAttempts: 90 });
   } catch (error) {
     console.error('Transaction rejected or failed to finalize:', error);
+    // Rethrow: swallowing this surfaces later as an unrelated assertion failure
+    // on a stale block, far away from the transaction that actually failed.
+    throw error;
   }
 }
 
@@ -283,6 +286,7 @@ async function sendTransactions(transactions: Mina.Transaction<any, any>[]) {
       console.log(`Success! Transaction sent. Txn hash: ${tx.hash}`);
     } catch (error) {
       console.error('Transaction rejected or failed to finalize:', error);
+      throw error;
     }
   }
 }


### PR DESCRIPTION
Closes #204.

## Problem

The live-network resolver tests query the archive immediately after `pendingTx.wait()` resolves. That wait is the **daemon** confirming inclusion — the archive node ingests the block into Postgres *asynchronously afterward*. When the query wins that race, `events[events.length - 1]` is still the previous suite's block, so the assertion reads the previous block's entry count.

This is what failed CI on #203 ([run 30536209372](https://github.com/o1-labs/Archive-Node-API/actions/runs/30536209372/job/90850039684)): `expected 3, actual 1`, where the preceding suite had emitted exactly one event. A re-run of the identical commit passed, and #203 changed only a version string — see #204 for the full evidence.

Note that "the emits got split across blocks" was never possible: `emitSingleEvent` puts all `numberOfEmits` emits inside a **single** `Mina.transaction` (`zkapp/utils.ts:106`), so once included they are necessarily in one block.

## Changes

**`tests/resolvers.test.ts`** — adds `waitForNewBlock`, plus `emitAndQueryEvents` / `emitAndQueryActions` wrappers, and routes all seven emit-then-query `before()` hooks through them (5 event suites, 2 action suites).

**`zkapp/utils.ts`** — `sendTransaction` and `sendTransactions` now rethrow after logging.

## Design note: why the poll predicate is content-independent

`waitForNewBlock` waits for *"a new block for this address is visible"* — it captures the block count before emitting and polls until it increases. It deliberately does **not** poll until the count matches what the test expects.

Polling on the expected value would make these assertions tautological: the test would spin until it passed, and a genuine wrong-count regression would surface as an opaque 30s timeout instead of a clean `expected 3, actual 2` diff. The bound is 30 attempts at 1s, and the timeout message states that the daemon already confirmed inclusion, so a failure points at archive lag rather than at the transaction.

## Why rethrowing matters

`sendTransaction` previously swallowed `wait()` failures:

```ts
} catch (error) {
  console.error('Transaction rejected or failed to finalize:', error);
}
```

A genuinely rejected or timed-out transaction produced *exactly* the same stale-block count mismatch as the race above, several lines away from the real cause. In the #203 failure the absence of that log line is what proved the transaction had actually succeeded — but that only worked because someone read the log closely. Rethrowing surfaces it at the origin.

## Verification

`npm run build` (tsc) and `npm run lint` clean. The behavioral proof is the `Run-Tests` job on this PR, which exercises these paths against `mina-local-network`.

Since this fixes a race, a single green run is evidence but not proof. The change is structural — there is no longer a query that can observe pre-ingestion state — rather than a timing tweak that widens a window.

## Not addressed here

The `NetworkState` suite (`tests/resolvers.test.ts:261-308`) has a related weakness: a hard-coded `setTimeout(25000)` and a direct archive-height vs daemon-height equality assertion that is racy in the same way. It is currently passing and fixing it would widen this diff considerably, so it is left for a follow-up — noted in #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)