### PR TITLE
ci: make schema and build jobs work without repository secrets (#214)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ coverage
 .github
 .memsearch
 .env*
+.npmrc
 db
 data
 *.log

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,18 +18,27 @@ env:
 
 jobs:
   build-and-deploy:
+    # This job authenticates to Google Cloud, publishes a dev npm package and
+    # pushes a Docker image, so it only works where repository secrets are
+    # available. GitHub passes no secrets to a pull request from a fork or from
+    # Dependabot, so the job is skipped there instead of failing at the auth
+    # step. Fork and Dependabot pull requests are still covered by Run-Tests,
+    # Linting, unit-tests, smoke-load, npm audit and Check Schema.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.pull_request.user.login != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Checkout PR branch
-        if: github.event_name == 'pull_request'
-        run: |
-          git fetch origin ${{github.event.pull_request.head.ref}}
-          git checkout ${{github.event.pull_request.head.sha}}
+          # Build the head commit of the pull request rather than the merge
+          # commit, which is what this job published before. The previous
+          # `git fetch origin <head ref>` assumed the branch lived in this
+          # repository and could not resolve a fork's branch.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.6.1
@@ -110,7 +119,13 @@ jobs:
         if: always() && steps.determine_npm_version.outputs.needs_version_update == 'true'
         run: |
           node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); pkg.version = '${{ steps.determine_npm_version.outputs.original_version }}'; fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');"
-          rm -f .npmrc
+
+      - name: Remove registry credentials from the workspace
+        # Unconditional, unlike the version restore above: `docker/build-push-action`
+        # runs later with `context: .`, so a live registry token must never be left
+        # on disk merely because the version-bump branch was not taken (#214).
+        if: always()
+        run: rm -f .npmrc
 
       - name: Determine tags
         id: determine_tags

--- a/.github/workflows/graphql-inspector.yaml
+++ b/.github/workflows/graphql-inspector.yaml
@@ -6,6 +6,14 @@ on:
     branches:
       - main
 
+# A pull request from a fork, or one opened by Dependabot, runs with a read-only
+# GITHUB_TOKEN. The previous implementation reported through a check run, which
+# needs `checks: write`, so it failed on every such pull request with
+# "Resource not accessible by integration". The gate is now the job's own exit
+# code, which needs no write access at all.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Check Schema
@@ -13,9 +21,28 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
-      - uses: kamilkisiela/graphql-inspector@master
+      - name: Install NodeJS
+        uses: actions/setup-node@v4
         with:
-          schema: 'main:schema.graphql'
-          approve-label: expected-breaking-change
+          node-version: '22'
+
+      - name: Fetch the base schema
+        run: git fetch --no-tags --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: Diff schema.graphql against main
+        env:
+          # Same escape hatch as before: a deliberate breaking change is approved
+          # by labelling the pull request, not by editing the workflow.
+          APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'expected-breaking-change') }}
+        run: |
+          set +e
+          npx --yes @graphql-inspector/cli@7.0.0 diff 'git:origin/main:schema.graphql' schema.graphql
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ] && [ "$APPROVED" = 'true' ]; then
+            echo "::warning::Breaking schema changes detected. Accepted because this pull request carries the expected-breaking-change label."
+            exit 0
+          fi
+          exit $status


### PR DESCRIPTION
## What & why

A pull request from a fork, and one opened by Dependabot, runs with a **read-only `GITHUB_TOKEN` and no repository secrets**. Two jobs assume otherwise and fail on every such pull request. This is currently red on **#225** (fork, community contribution) and **#226** (Dependabot).

### 1. `Check Schema` — could not report

```
##[error]Resource not accessible by integration - .../checks/runs#create-a-check-run
```

`kamilkisiela/graphql-inspector@master` reports by creating a check run, which needs `checks: write`. Adding a `permissions:` block does **not** help: GitHub caps the token at read-only for these events whatever the workflow asks for.

The gate is now `npx @graphql-inspector/cli@7.0.0 diff 'git:origin/main:schema.graphql' schema.graphql`, whose **exit code is the job result** — no API write, so it works from a fork. Behaviour kept: the `expected-breaking-change` label still approves a deliberate breaking change. Side benefit: `actions/checkout@master` and `graphql-inspector@master` were unpinned; both are now pinned.

### 2. `build-and-deploy` — could not authenticate, and could not check out a fork

```
##[error]google-github-actions/auth failed with: … By default, secrets are not passed
to workflows triggered from forks, including Dependabot.
```

and, on forks only, one step earlier:

```
fatal: couldn't find remote ref feat/verification-key-updates
```

This job authenticates to Google Cloud, writes a registry token, **publishes a dev npm package** and pushes an image. None of that can or should run for an untrusted pull request — the failure is GitHub's protection working, not a bug to fix by handing over secrets. So the job is now **skipped** for fork and Dependabot pull requests instead of failing at the auth step, and the checkout resolves the head SHA through `actions/checkout` rather than `git fetch origin <head ref>`, which cannot resolve a branch living in a fork.

Coverage for those pull requests is unchanged otherwise: `Run-Tests`, `Linting`, `unit-tests`, `smoke-load`, `npm audit`, `SBOM` and `Check Schema` all still run. Both required checks (`Run-Tests`, `Linting`) are unaffected.

### 3. Registry credential in the Docker build context — closes #214

`.npmrc` holds a live GCP access token, and the step that deleted it only ran when `needs_version_update == 'true'`. `docker/build-push-action` runs later in the same job with `context: .`, so on any other build the token was uploaded into the build context. Nothing copies it into a layer today; the hazard is one `COPY . .` away.

- `rm -f .npmrc` split into its own step and made unconditional.
- `.npmrc` added to `.dockerignore`.

The `package.json` version restore keeps its original condition.

## Testing

- `actionlint` — clean on both changed workflows.
- Schema gate, run locally against this repo: unchanged schema → `[success] No changes detected`, exit **0**. With `parentHash` deleted from `BlockInfo` → `✖ Field parentHash was removed from object type BlockInfo` / `[error] Detected 1 breaking change`, exit **1**. So the gate still fails the build on a breaking change.
- `.dockerignore`, verified with a throwaway image that does `COPY . /ctx` over a workspace containing a fake `.npmrc`: with the new line the file is absent from the context (build passes); with the line removed the same build **fails** — a negative control proving the test is meaningful.

## Follow-up, not in this PR

Once this lands, `Check Schema` can pass from a fork, which unblocks making it a required status check — tracked in #213.

Note on ordering: for `pull_request` events GitHub runs the workflow files from the merge ref, so #225 and #226 need their runs re-triggered after this merges (both are behind `main` anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LtdRKTkaKRAuTkEEpgPcc
